### PR TITLE
Add circle ci config for running tests across PHP versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,7 @@ RUN phpize && \
     make test && \
     make install
 
+RUN vendor/bin/phpcs --standard=./phpcs-ruleset.xml
+
 RUN composer install &&
     vendor/bin/phpunit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+RUN mkdir -p /build && \
+    apt-get update -y && \
+    apt-get install -y -q --no-install-recommends \
+        build-essential \
+        g++ \
+        gcc \
+        libc-dev \
+        make \
+        autoconf
+
+COPY . /build/
+
+WORKDIR /build
+
+ENV TEST_PHP_ARGS="-q" \
+    REPORT_EXIT_STATUS=1
+
+RUN phpize && \
+    ./configure --enable-stackdriver-trace && \
+    make clean && \
+    make && \
+    make test && \
+    make install
+
+RUN composer install &&
+    vendor/bin/phpunit

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN mkdir -p /build && \
 
 COPY . /build/
 
-WORKDIR /build
+WORKDIR /build/ext
 
 ENV TEST_PHP_ARGS="-q" \
     REPORT_EXIT_STATUS=1
@@ -38,6 +38,8 @@ RUN phpize && \
     make && \
     make test && \
     make install
+
+WORKDIR /build
 
 RUN composer install && \
     vendor/bin/phpcs --standard=./phpcs-ruleset.xml && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ RUN phpize && \
     make test && \
     make install
 
-RUN vendor/bin/phpcs --standard=./phpcs-ruleset.xml
-
-RUN composer install &&
+RUN composer install && \
+    vendor/bin/phpcs --standard=./phpcs-ruleset.xml && \
     vendor/bin/phpunit

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+machine:
+  timezone: America/Los_Angeles
+  environment:
+    GCLOUD_DIR: ${HOME}/gcloud
+    PATH: ${GCLOUD_DIR}/google-cloud-sdk/bin:${PATH}
+    CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+    CLOUDSDK_ACTIVE_CONFIG_NAME: opencensus-php
+    TEST_BUILD_DIR: ${HOME}
+    PHP_DOCKER_GOOGLE_CREDENTIALS: ${HOME}/credentials.json
+    GOOGLE_PROJECT_ID: php-stackdriver
+    TAG: circle-${CIRCLE_BUILD_NUM}
+
+dependencies:
+  override:
+    - scripts/install_test_dependencies.sh
+
+test:
+  override:
+    - scripts/run_test_suite.sh

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,14 @@
+# This cloudbuild.yaml is used to test the php extension against multiple versions of php
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args: ['build', '--build-arg', 'BASE_IMAGE=gcr.io/google-appengine/php71', '.']
+    waitFor: ['-']
+    id: php71
+  - name: gcr.io/cloud-builders/docker
+    args: ['build', '--build-arg', 'BASE_IMAGE=gcr.io/google-appengine/php70', '.']
+    waitFor: ['-']
+    id: php70
+  - name: gcr.io/cloud-builders/docker
+    args: ['build', '--build-arg', 'BASE_IMAGE=gcr.io/php-mvm-a/php72:alpha3', '.']
+    waitFor: ['-']
+    id: php72

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "cache/adapter-common": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "4.8.*",
+        "squizlabs/php_codesniffer": "2.*"
     },
     "suggest": {
         "cache/apcu-adapter": "Enable QpsSampler to use apcu cache.",

--- a/phpcs-ruleset.xml
+++ b/phpcs-ruleset.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset name="Google-Cloud-PHP-PSR2">
+  <rule ref="PSR2" />
+  <file>src</file>
+</ruleset>

--- a/scripts/dump_credentials.php
+++ b/scripts/dump_credentials.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Copyright 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Dumps the contents of the environment variable GOOGLE_CREDENTIALS_BASE64 to
+ * a file.
+ *
+ * To setup Travis to run on your fork, read TRAVIS.md.
+ */
+if (getenv('GOOGLE_CREDENTIALS_BASE64') === false) {
+    exit(0);
+}
+file_put_contents(
+    getenv('PHP_DOCKER_GOOGLE_CREDENTIALS'),
+    base64_decode(getenv('GOOGLE_CREDENTIALS_BASE64'))
+);

--- a/scripts/install_test_dependencies.sh
+++ b/scripts/install_test_dependencies.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script for installing necessary software on CI systems.
+
+set -ex
+
+if [ "${INSTALL_GCLOUD}" == "true" ]; then
+    # Install gcloud
+    if [ ! -d ${HOME}/gcloud/google-cloud-sdk ]; then
+        mkdir -p ${HOME}/gcloud &&
+        wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz --directory-prefix=${HOME}/gcloud &&
+        cd "${HOME}/gcloud" &&
+            tar xzf google-cloud-sdk.tar.gz &&
+            ./google-cloud-sdk/install.sh --usage-reporting false --path-update false --command-completion false &&
+            cd "${TEST_BUILD_DIR}";
+    fi
+fi
+
+if [ -z "${CLOUDSDK_ACTIVE_CONFIG_NAME}" ]; then
+    echo "You need to set CLOUDSDK_ACTIVE_CONFIG_NAME envvar."
+    exit 1
+fi
+
+if [ -z "${GOOGLE_PROJECT_ID}" ]; then
+    echo "You need to set GOOGLE_PROJECT_ID envvar."
+    exit 1
+fi
+
+if [ -z "${CLOUDSDK_VERBOSITY}" ]; then
+    CLOUDSDK_VERBOSITY='none'
+fi
+
+# gcloud configurations
+gcloud config configurations create ${CLOUDSDK_ACTIVE_CONFIG_NAME} || /bin/true # ignore failure
+gcloud config set project ${GOOGLE_PROJECT_ID}
+gcloud config set app/promote_by_default false
+gcloud config set verbosity ${CLOUDSDK_VERBOSITY}
+
+# Dump the credentials from the environment variable.
+php scripts/dump_credentials.php
+
+# Set the timeout
+gcloud config set container/build_timeout 3600
+
+if [ ! -f "${PHP_DOCKER_GOOGLE_CREDENTIALS}" ]; then
+    echo 'Please set PHP_DOCKER_GOOGLE_CREDENTIALS envvar.'
+    exit 1
+fi
+
+# Use the service account for gcloud operations.
+gcloud auth activate-service-account \
+    --key-file "${PHP_DOCKER_GOOGLE_CREDENTIALS}"
+
+if [ "${CIRCLECI}" == "true" ]; then
+    # Need sudo on circleci:
+    # https://discuss.circleci.com/t/gcloud-components-update-version-restriction/3725
+    # They also overrides the PATH to use
+    # /opt/google-cloud-sdk/bin/gcloud so we can not easily use our
+    # own gcloud
+    sudo /opt/google-cloud-sdk/bin/gcloud -q components update beta
+else
+    gcloud -q components update beta
+fi

--- a/scripts/run_test_suite.sh
+++ b/scripts/run_test_suite.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script for installing necessary software on CI systems.
+
+set -ex
+
+gcloud container builds submit --config=cloudbuild.yaml .

--- a/tests/unit/Trace/Reporter/EchoReporterTest.php
+++ b/tests/unit/Trace/Reporter/EchoReporterTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace\Reporter;
+namespace OpenCensus\Tests\Unit\Trace\Reporter;
 
 use OpenCensus\Trace\Reporter\EchoReporter;
 use OpenCensus\Trace\TraceContext;

--- a/tests/unit/Trace/Reporter/FileReporterTest.php
+++ b/tests/unit/Trace/Reporter/FileReporterTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace\Reporter;
+namespace OpenCensus\Tests\Unit\Trace\Reporter;
 
 use OpenCensus\Trace\Reporter\FileReporter;
 use OpenCensus\Trace\TraceContext;

--- a/tests/unit/Trace/Reporter/LoggerReporterTest.php
+++ b/tests/unit/Trace/Reporter/LoggerReporterTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace\Reporter;
+namespace OpenCensus\Tests\Unit\Trace\Reporter;
 
 use Psr\Log\LoggerInterface;
 use OpenCensus\Trace\Reporter\LoggerReporter;

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace;
+namespace OpenCensus\Tests\Unit\Trace;
 
 use OpenCensus\Trace\TraceSpan;
 use OpenCensus\Trace\RequestHandler;

--- a/tests/unit/Trace/RequestTracerTest.php
+++ b/tests/unit/Trace/RequestTracerTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace;
+namespace OpenCensus\Tests\Unit\Trace;
 
 use OpenCensus\Trace\Reporter\ReporterInterface;
 use OpenCensus\Trace\RequestTracer;

--- a/tests/unit/Trace/Sampler/QpsSamplerTest.php
+++ b/tests/unit/Trace/Sampler/QpsSamplerTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace\Sampler;
+namespace OpenCensus\Tests\Unit\Trace\Sampler;
 
 use OpenCensus\Trace\Sampler\QpsSampler;
 use Psr\Cache\CacheItemInterface;

--- a/tests/unit/Trace/Sampler/RandomSamplerTest.php
+++ b/tests/unit/Trace/Sampler/RandomSamplerTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace\Sampler;
+namespace OpenCensus\Tests\Unit\Trace\Sampler;
 
 use OpenCensus\Trace\Sampler\RandomSampler;
 

--- a/tests/unit/Trace/Sampler/SamplerFactoryTest.php
+++ b/tests/unit/Trace/Sampler/SamplerFactoryTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace\Sampler;
+namespace OpenCensus\Tests\Unit\Trace\Sampler;
 
 use OpenCensus\Trace\Sampler\SamplerFactory;
 use OpenCensus\Trace\Sampler\SamplerInterface;

--- a/tests/unit/Trace/TraceContextTest.php
+++ b/tests/unit/Trace/TraceContextTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace;
+namespace OpenCensus\Tests\Unit\Trace;
 
 use OpenCensus\Trace\TraceContext;
 

--- a/tests/unit/Trace/TraceSpanTest.php
+++ b/tests/unit/Trace/TraceSpanTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace;
+namespace OpenCensus\Tests\Unit\Trace;
 
 use OpenCensus\Trace\TraceSpan;
 

--- a/tests/unit/Trace/TraceTest.php
+++ b/tests/unit/Trace/TraceTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace;
+namespace OpenCensus\Tests\Unit\Trace;
 
 use OpenCensus\Trace\Trace;
 use OpenCensus\Trace\TraceSpan;

--- a/tests/unit/Trace/Tracer/ContextTracerTest.php
+++ b/tests/unit/Trace/Tracer/ContextTracerTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace\Tracer;
+namespace OpenCensus\Tests\Unit\Trace\Tracer;
 
 use OpenCensus\Trace\TraceContext;
 use OpenCensus\Trace\Tracer\ContextTracer;

--- a/tests/unit/Trace/Tracer/ExtentionTracerTest.php
+++ b/tests/unit/Trace/Tracer/ExtentionTracerTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Google\Cloud\Tests\Unit\Trace\Tracer;
+namespace OpenCensus\Tests\Unit\Trace\Tracer;
 
 use OpenCensus\Trace\TraceContext;
 use OpenCensus\Trace\Tracer\ExtensionTracer;


### PR DESCRIPTION
Runs in cloudbuild to test across multiple PHP versions.

We run 3 tests in the containers:
1. Build the PHP extension and run its tests
2. Run PHP CS against the PSR2 standard rules
3. Run the PHP library's PHPUnit tests