### PR TITLE
Add Google Cloud Reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenCensus - A stats collection and distributed tracing framework
 
-This is the open-source release of Census for Python. Census provides a
+This is the open-source release of Census for PHP. Census provides a
 framework to measure a server's resource usage and collect performance stats.
 This repository contains PHP related utilities and supporting software needed by
 Census.
@@ -46,6 +46,17 @@ The above sample uses the `EchoReporter` to dump trace results to the
 bottom of the webpage.
 
 If you would like to provide your own reporter, create a class that implements `ReporterInterface`.
+
+Currently implemented reporters:
+
+| Class | Description |
+| ----- | ----------- |
+| [EchoReporter](src/Trace/Reporter/EchoReporter.php) | Output the collected spans to stdout |
+| [FileReporter](src/Trace/Reporter/FileReporter.php) | Output JSON encoded spans to a file |
+| [GoogleCloudReporter](src/Trace/Reporter/GoogleCloudReporter.php) | Report traces to Google Cloud Stackdriver Trace |
+| [LoggerReporter](src/Trace/Reporter/LoggerReporter.php) | Reporter JSON encoded spans to a PSR-3 logger |
+| [NullReporter](scr/Trace/Reporter/NullReporter.php) | No-op |
+| [ZipkinReporter](src/Trace/Reporter/ZipkinReporter.php) | Report collected spans to a Zipkin server |
 
 ### Sampling Rate
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "2.*",
+        "google/cloud-trace": "^0.3"
     },
     "suggest": {
         "cache/apcu-adapter": "Enable QpsSampler to use apcu cache.",

--- a/src/Trace/Reporter/GoogleCloudReporter.php
+++ b/src/Trace/Reporter/GoogleCloudReporter.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Reporter;
+
+use Google\Cloud\Core\Batch\BatchRunner;
+use Google\Cloud\Core\Batch\BatchTrait;
+use Google\Cloud\Trace\TraceClient;
+use Google\Cloud\Trace\Tracer\TracerInterface;
+
+/**
+ * This implementation of the ReporterInterface use the BatchRunner to provide
+ * reporting of Traces and their TraceSpans to Google Cloud Stackdriver Trace.
+ *
+ * @experimental The experimental flag means that while we believe this method
+ *      or class is ready for use, it may change before release in backwards-
+ *      incompatible ways. Please use with caution, and test thoroughly when
+ *      upgrading.
+ */
+class GoogleCloudReporter implements ReporterInterface
+{
+    const VERSION = '0.1.0';
+    const DEFAULT_ROOT_SPAN_NAME = 'main';
+
+    // These are Stackdriver Trace's common labels
+    const AGENT = '/agent';
+    const COMPONENT = '/component';
+    const ERROR_MESSAGE = '/error/message';
+    const ERROR_NAME = '/error/name';
+    const HTTP_CLIENT_CITY = '/http/client_city';
+    const HTTP_CLIENT_COUNTRY = '/http/client_country';
+    const HTTP_CLIENT_PROTOCOL = '/http/client_protocol';
+    const HTTP_CLIENT_REGION = '/http/client_region';
+    const HTTP_HOST = '/http/host';
+    const HTTP_METHOD = '/http/method';
+    const HTTP_REDIRECTED_URL = '/http/redirected_url';
+    const HTTP_STATUS_CODE = '/http/status_code';
+    const HTTP_URL = '/http/url';
+    const HTTP_USER_AGENT = '/http/user_agent';
+    const PID = '/pid';
+    const STACKTRACE = '/stacktrace';
+    const TID = '/tid';
+
+    const GAE_APPLICATION_ERROR = 'g.co/gae/application_error';
+    const GAE_APP_MODULE = 'g.co/gae/app/module';
+    const GAE_APP_MODULE_VERSION = 'g.co/gae/app/module_version';
+    const GAE_APP_VERSION = 'g.co/gae/app/version';
+
+    use BatchTrait;
+
+    /**
+     * @var TraceClient
+     */
+    private static $client;
+
+    /**
+     * @var bool
+     */
+    private $async;
+
+    /**
+     * Create a TraceReporter that utilizes background batching.
+     *
+     * @param array $options [optional] {
+     *     Configuration options.
+     *
+     *     @type TraceClient $client A trace client used to instantiate traces
+     *           to be delivered to the batch queue.
+     *     @type bool $debugOutput Whether or not to output debug information.
+     *           Please note debug output currently only applies in CLI based
+     *           applications. **Defaults to** `false`.
+     *     @type array $batchOptions A set of options for a BatchJob.
+     *           {@see \Google\Cloud\Core\Batch\BatchJob::__construct()} for
+     *           more details.
+     *           **Defaults to** ['batchSize' => 1000,
+     *                            'callPeriod' => 2.0,
+     *                            'workerNum' => 2].
+     *     @type array $clientConfig Configuration options for the Trace client
+     *           used to handle processing of batch items.
+     *           For valid options please see
+     *           {@see \Google\Cloud\Trace\TraceClient::__construct()}.
+     *     @type BatchRunner $batchRunner A BatchRunner object. Mainly used for
+     *           the tests to inject a mock. **Defaults to** a newly created
+     *           BatchRunner.
+     *     @type string $identifier An identifier for the batch job.
+     *           **Defaults to** `stackdriver-trace`.
+     *     @type bool $async Whether we should try to use the batch runner.
+     *           **Defaults to** `false`.
+     * }
+     */
+    public function __construct(array $options = [])
+    {
+        $this->async = isset($options['async']) ? $options['async'] : false;
+        $this->setCommonBatchProperties($options + [
+            'identifier' => 'stackdriver-trace',
+            'batchMethod' => 'insertBatch'
+        ]);
+        self::$client = isset($options['client'])
+            ? $options['client']
+            : new TraceClient($this->clientConfig);
+    }
+
+    /**
+     * Report the provided Trace to a backend.
+     *
+     * @param  TracerInterface $tracer
+     * @return bool
+     */
+    public function report(TracerInterface $tracer)
+    {
+        $this->addCommonLabels($tracer);
+
+        $spans = $tracer->spans();
+
+        if (empty($spans)) {
+            return false;
+        }
+
+        $trace = self::$client->trace(
+            $tracer->context()->traceId()
+        );
+        $trace->setSpans($spans);
+
+        try {
+            if ($this->async) {
+                return $this->batchRunner->submitItem($this->identifier, $trace);
+            } else {
+                return self::$client->insert($trace);
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns an array representation of a callback which will be used to write
+     * batch items.
+     *
+     * @return array
+     */
+    protected function getCallback()
+    {
+        if (!isset(self::$client)) {
+            self::$client = new TraceClient($this->clientConfig);
+        }
+
+        return [self::$client, $this->batchMethod];
+    }
+
+    private function addCommonLabels(&$tracer)
+    {
+        // If a redirect, add the HTTP_REDIRECTED_URL label to the main span
+        $responseCode = http_response_code();
+        if ($responseCode == 301 || $responseCode == 302) {
+            foreach (headers_list() as $header) {
+                if (substr($header, 0, 9) == 'Location:') {
+                    $tracer->addRootLabel(self::HTTP_REDIRECTED_URL, substr($header, 10));
+                    break;
+                }
+            }
+        }
+        $tracer->addRootLabel(self::HTTP_STATUS_CODE, $responseCode);
+
+        $labelMap = [
+            self::HTTP_URL => ['REQUEST_URI'],
+            self::HTTP_METHOD => ['REQUEST_METHOD'],
+            self::HTTP_CLIENT_PROTOCOL => ['SERVER_PROTOCOL'],
+            self::HTTP_USER_AGENT => ['HTTP_USER_AGENT'],
+            self::HTTP_HOST => ['HTTP_HOST', 'SERVER_NAME'],
+            self::GAE_APP_MODULE => ['GAE_SERVICE'],
+            self::GAE_APP_MODULE_VERSION => ['GAE_VERSION'],
+            self::HTTP_CLIENT_CITY => ['HTTP_X_APPENGINE_CITY'],
+            self::HTTP_CLIENT_REGION => ['HTTP_X_APPENGINE_REGION'],
+            self::HTTP_CLIENT_COUNTRY => ['HTTP_X_APPENGINE_COUNTRY']
+        ];
+        foreach ($labelMap as $labelKey => $headerKeys) {
+            if ($val = $this->detectKey($headerKeys, $headers)) {
+                $tracer->addRootLabel($labelKey, $val);
+            }
+        }
+        $tracer->addRootLabel(self::PID, '' . getmypid());
+        $tracer->addRootLabel(self::AGENT, 'opencensus ' . self::VERSION);
+    }
+
+    private function detectKey(array $keys, array $array)
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $array)) {
+                return $array[$key];
+            }
+        }
+        return null;
+    }
+}

--- a/src/Trace/Reporter/GoogleCloudReporter.php
+++ b/src/Trace/Reporter/GoogleCloudReporter.php
@@ -27,6 +27,40 @@ use OpenCensus\Trace\Tracer\TracerInterface;
  * This implementation of the ReporterInterface use the BatchRunner to provide
  * reporting of Traces and their TraceSpans to Google Cloud Stackdriver Trace.
  *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\RequestTracer;
+ * use OpenCensus\Trace\Reporter\GoogleCloudReporter;
+ *
+ * $reporter = new GoogleCloudReporter([
+ *   'clientConfig' => [
+ *      'projectId' => 'my-project'
+ *   ]
+ * ]);
+ * RequestTracer::start($reporter);
+ * ```
+ *
+ * The above configuration will synchronously report the traces to Google Cloud
+ * Stackdriver Trace. You can enable an experimental asynchronous reporting
+ * mechanism using (BatchDaemon)[https://github.com/GoogleCloudPlatform/google-cloud-php/tree/master/src/Core/Batch].
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\RequestTracer;
+ * use OpenCensus\Trace\Reporter\GoogleCloudReporter;
+ *
+ * $reporter = new GoogleCloudReporter([
+ *   'async' => true,
+ *   'clientConfig' => [
+ *      'projectId' => 'my-project'
+ *   ]
+ * ]);
+ * RequestTracer::start($reporter);
+ * ```
+ *
+ * Note that to use the `async` option, you will also need to set the
+ * `IS_BATCH_DAEMON_RUNNING` environment variable to `true`.
+ *
  * @experimental The experimental flag means that while we believe this method
  *      or class is ready for use, it may change before release in backwards-
  *      incompatible ways. Please use with caution, and test thoroughly when

--- a/src/Trace/RequestHandler.php
+++ b/src/Trace/RequestHandler.php
@@ -35,6 +35,8 @@ use OpenCensus\Trace\Propagator\PropagatorInterface;
  */
 class RequestHandler
 {
+    const DEFAULT_ROOT_SPAN_NAME = 'main';
+
     /**
      * @var ReporterInterface The reported to use at the end of the request
      */
@@ -93,7 +95,6 @@ class RequestHandler
             'name' => $this->nameFromHeaders($headers),
             'labels' => []
         ];
-        $spanOptions['labels'] += $this->labelsFromHeaders($headers);
         $this->tracer->startSpan($spanOptions);
 
         register_shutdown_function([$this, 'onExit']);

--- a/src/Trace/RequestHandler.php
+++ b/src/Trace/RequestHandler.php
@@ -34,33 +34,6 @@ use OpenCensus\Trace\Tracer\TracerInterface;
  */
 class RequestHandler
 {
-    const VERSION = '0.1.0';
-
-    const DEFAULT_ROOT_SPAN_NAME = 'main';
-
-    const AGENT = '/agent';
-    const COMPONENT = '/component';
-    const ERROR_MESSAGE = '/error/message';
-    const ERROR_NAME = '/error/name';
-    const HTTP_CLIENT_CITY = '/http/client_city';
-    const HTTP_CLIENT_COUNTRY = '/http/client_country';
-    const HTTP_CLIENT_PROTOCOL = '/http/client_protocol';
-    const HTTP_CLIENT_REGION = '/http/client_region';
-    const HTTP_HOST = '/http/host';
-    const HTTP_METHOD = '/http/method';
-    const HTTP_REDIRECTED_URL = '/http/redirected_url';
-    const HTTP_STATUS_CODE = '/http/status_code';
-    const HTTP_URL = '/http/url';
-    const HTTP_USER_AGENT = '/http/user_agent';
-    const PID = '/pid';
-    const STACKTRACE = '/stacktrace';
-    const TID = '/tid';
-
-    const GAE_APPLICATION_ERROR = 'g.co/gae/application_error';
-    const GAE_APP_MODULE = 'g.co/gae/app/module';
-    const GAE_APP_MODULE_VERSION = 'g.co/gae/app/module_version';
-    const GAE_APP_VERSION = 'g.co/gae/app/version';
-
     /**
      * @var ReporterInterface The reported to use at the end of the request
      */
@@ -124,20 +97,6 @@ class RequestHandler
      */
     public function onExit()
     {
-        $responseCode = http_response_code();
-
-        // If a redirect, add the HTTP_REDIRECTED_URL label to the main span
-        if ($responseCode == 301 || $responseCode == 302) {
-            foreach (headers_list() as $header) {
-                if (substr($header, 0, 9) == 'Location:') {
-                    $this->tracer->addRootLabel(self::HTTP_REDIRECTED_URL, substr($header, 10));
-                    break;
-                }
-            }
-        }
-
-        $this->tracer->addRootLabel(self::HTTP_STATUS_CODE, $responseCode);
-
         // close all open spans
         do {
             $span = $this->tracer->endSpan();
@@ -206,7 +165,13 @@ class RequestHandler
 
     private function startTimeFromHeaders(array $headers)
     {
-        return $this->detectKey(['REQUEST_TIME_FLOAT', 'REQUEST_TIME'], $headers);
+        if (array_key_exists('REQUEST_TIME_FLOAT', $headers)) {
+            return $headers['REQUEST_TIME_FLOAT'];
+        }
+        if (array_key_exists('REQUEST_TIME', $headers)) {
+            return $headers['REQUEST_TIME'];
+        }
+        return null;
     }
 
     private function nameFromHeaders(array $headers)
@@ -215,44 +180,6 @@ class RequestHandler
             return $headers['REQUEST_URI'];
         }
         return self::DEFAULT_ROOT_SPAN_NAME;
-    }
-
-    private function labelsFromHeaders(array $headers)
-    {
-        $labels = [];
-
-        $labelMap = [
-            self::HTTP_URL => ['REQUEST_URI'],
-            self::HTTP_METHOD => ['REQUEST_METHOD'],
-            self::HTTP_CLIENT_PROTOCOL => ['SERVER_PROTOCOL'],
-            self::HTTP_USER_AGENT => ['HTTP_USER_AGENT'],
-            self::HTTP_HOST => ['HTTP_HOST', 'SERVER_NAME'],
-            self::GAE_APP_MODULE => ['GAE_SERVICE'],
-            self::GAE_APP_MODULE_VERSION => ['GAE_VERSION'],
-            self::HTTP_CLIENT_CITY => ['HTTP_X_APPENGINE_CITY'],
-            self::HTTP_CLIENT_REGION => ['HTTP_X_APPENGINE_REGION'],
-            self::HTTP_CLIENT_COUNTRY => ['HTTP_X_APPENGINE_COUNTRY']
-        ];
-        foreach ($labelMap as $labelKey => $headerKeys) {
-            if ($val = $this->detectKey($headerKeys, $headers)) {
-                $labels[$labelKey] = $val;
-            }
-        }
-
-        $labels[self::PID] = '' . getmypid();
-        $labels[self::AGENT] = 'opencensus ' . self::VERSION;
-
-        return $labels;
-    }
-
-    private function detectKey(array $keys, array $array)
-    {
-        foreach ($keys as $key) {
-            if (array_key_exists($key, $array)) {
-                return $array[$key];
-            }
-        }
-        return null;
     }
 
     private function persistContextHeader($context)

--- a/tests/unit/Trace/Reporter/GoogleCloudReporterTest.php
+++ b/tests/unit/Trace/Reporter/GoogleCloudReporterTest.php
@@ -19,10 +19,11 @@ namespace OpenCensus\Tests\Unit\Trace\Reporter;
 
 use OpenCensus\Trace\Reporter\GoogleCloudReporter;
 use OpenCensus\Trace\TraceContext;
-use OpenCensus\Trace\TraceSpan;
 use OpenCensus\Trace\Tracer\TracerInterface;
+use OpenCensus\Trace\Tracer\ContextTracer;
 use Prophecy\Argument;
 use Google\Cloud\Trace\Trace;
+use Google\Cloud\Trace\TraceSpan;
 use Google\Cloud\Trace\TraceClient;
 
 /**
@@ -30,34 +31,56 @@ use Google\Cloud\Trace\TraceClient;
  */
 class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
 {
-    private $tracer;
-    private $client;
-
-    public function setUp()
+    public function testFormatsTrace()
     {
-        $this->tracer = $this->prophesize(TracerInterface::class);
-        $this->client = $this->prophesize(TraceClient::class);
+        $tracer = new ContextTracer(new TraceContext('testtraceid'));
+        $tracer->inSpan(['name' => 'main'], function () use ($tracer) {
+            $tracer->inSpan(['name' => 'span1'], 'usleep', [10]);
+            $tracer->inSpan(['name' => 'span2'], 'usleep', [20]);
+        });
+
+        $reporter = new GoogleCloudReporter();
+        $spans = $reporter->convertSpans($tracer);
+
+        $this->assertCount(3, $spans);
+        foreach ($spans as $span) {
+            $this->assertInstanceOf(TraceSpan::class, $span);
+            $this->assertInternalType('string', $span->name());
+            $this->assertInternalType('int', $span->spanId());
+            $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $span->info()['startTime']);
+            $this->assertRegExp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z/', $span->info()['endTime']);
+        }
     }
 
-    public function testLogsTrace()
+    /**
+     * @dataProvider labelHeaders
+     */
+    public function testParsesDefaultLabels($headerKey, $headerValue, $expectedLabelKey, $expectedLabelValue)
     {
-        $spans = [
-            new TraceSpan([
-                'name' => 'span',
-                'startTime' => microtime(true),
-                'endTime' => microtime(true) + 10
-            ])
+        $tracer = new ContextTracer(new TraceContext('testtraceid'));
+        $tracer->inSpan(['name' => 'main'], function () {});
+
+        $reporter = new GoogleCloudReporter();
+        $reporter->processSpans($tracer, [$headerKey => $headerValue]);
+        $spans = $tracer->spans();
+        $labels = $spans[0]->labels();
+        $this->assertArrayHasKey($expectedLabelKey, $labels);
+        $this->assertEquals($expectedLabelValue, $labels[$expectedLabelKey]);
+    }
+
+    public function labelHeaders()
+    {
+        return [
+            ['REQUEST_URI', '/foobar', '/http/url', '/foobar'],
+            ['REQUEST_METHOD', 'PUT', '/http/method', 'PUT'],
+            ['SERVER_PROTOCOL', 'https', '/http/client_protocol', 'https'],
+            ['HTTP_HOST', 'foo.example.com', '/http/host', 'foo.example.com'],
+            ['SERVER_NAME', 'foo.example.com', '/http/host', 'foo.example.com'],
+            ['GAE_SERVICE', 'test-app', 'g.co/gae/app/module', 'test-app'],
+            ['GAE_VERSION', 't12345', 'g.co/gae/app/module_version', 't12345'],
+            ['HTTP_X_APPENGINE_CITY', 'kirkland', '/http/client_city', 'kirkland'],
+            ['HTTP_X_APPENGINE_REGION', 'wa', '/http/client_region', 'wa'],
+            ['HTTP_X_APPENGINE_COUNTRY', 'US', '/http/client_country', 'US']
         ];
-        $this->tracer->context()->willReturn(new TraceContext('testtraceid'));
-        $this->tracer->spans()->willReturn($spans);
-        $this->tracer->addRootLabel(Argument::type('string'), Argument::any())->willReturn(true);
-        $this->client->insert(Argument::type(Trace::class))->willReturn(true);
-        $this->client->trace('testtraceid')->willReturn(true);
-
-        $reporter = new GoogleCloudReporter([
-            'client' => $this->client->reveal()
-        ]);
-
-        $this->assertTrue($reporter->report($this->tracer->reveal()));
     }
 }

--- a/tests/unit/Trace/Reporter/GoogleCloudReporterTest.php
+++ b/tests/unit/Trace/Reporter/GoogleCloudReporterTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Unit\Trace\Reporter;
+
+use OpenCensus\Trace\Reporter\GoogleCloudReporter;
+use OpenCensus\Trace\TraceContext;
+use OpenCensus\Trace\TraceSpan;
+use OpenCensus\Trace\Tracer\TracerInterface;
+use Prophecy\Argument;
+use Google\Cloud\Trace\Trace;
+use Google\Cloud\Trace\TraceClient;
+
+/**
+ * @group trace
+ */
+class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
+{
+    private $tracer;
+    private $client;
+
+    public function setUp()
+    {
+        $this->tracer = $this->prophesize(TracerInterface::class);
+        $this->client = $this->prophesize(TraceClient::class);
+    }
+
+    public function testLogsTrace()
+    {
+        $spans = [
+            new TraceSpan([
+                'name' => 'span',
+                'startTime' => microtime(true),
+                'endTime' => microtime(true) + 10
+            ])
+        ];
+        $this->tracer->context()->willReturn(new TraceContext('testtraceid'));
+        $this->tracer->spans()->willReturn($spans);
+        $this->tracer->addRootLabel(Argument::type('string'), Argument::any())->willReturn(true);
+        $this->client->insert(Argument::type(Trace::class))->willReturn(true);
+        $this->client->trace('testtraceid')->willReturn(true);
+
+        $reporter = new GoogleCloudReporter([
+            'client' => $this->client->reveal()
+        ]);
+
+        $this->assertTrue($reporter->report($this->tracer->reveal()));
+    }
+}

--- a/tests/unit/Trace/Reporter/GoogleCloudReporterTest.php
+++ b/tests/unit/Trace/Reporter/GoogleCloudReporterTest.php
@@ -31,6 +31,14 @@ use Google\Cloud\Trace\TraceClient;
  */
 class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
 {
+    private $client;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->client = $this->prophesize(TraceClient::class);
+    }
+
     public function testFormatsTrace()
     {
         $tracer = new ContextTracer(new TraceContext('testtraceid'));
@@ -39,7 +47,7 @@ class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
             $tracer->inSpan(['name' => 'span2'], 'usleep', [20]);
         });
 
-        $reporter = new GoogleCloudReporter();
+        $reporter = new GoogleCloudReporter(['client' => $this->client->reveal()]);
         $spans = $reporter->convertSpans($tracer);
 
         $this->assertCount(3, $spans);
@@ -60,7 +68,7 @@ class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer(new TraceContext('testtraceid'));
         $tracer->inSpan(['name' => 'main'], function () {});
 
-        $reporter = new GoogleCloudReporter();
+        $reporter = new GoogleCloudReporter(['client' => $this->client->reveal()]);
         $reporter->processSpans($tracer, [$headerKey => $headerValue]);
         $spans = $tracer->spans();
         $labels = $spans[0]->labels();

--- a/tests/unit/Trace/Reporter/ZipkinReporterTest.php
+++ b/tests/unit/Trace/Reporter/ZipkinReporterTest.php
@@ -52,8 +52,7 @@ class ZipkinReporterTest extends \PHPUnit_Framework_TestCase
 
         $reporter = new ZipkinReporter('myapp', 'localhost', 9411);
 
-        $json = $reporter->serialize($this->tracer->reveal());
-        $data = json_decode($json, true);
+        $data = $reporter->convertSpans($this->tracer->reveal());
 
         $this->assertInternalType('array', $data);
         foreach ($data as $span) {

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -64,48 +64,6 @@ class RequestHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($spans[0]->spanId(), $spans[1]->info()['parentSpanId']);
     }
 
-    public function testCanParseLabels()
-    {
-        $this->sampler->shouldSample()->willReturn(true);
-
-        $rt = new RequestHandler(
-            $this->reporter->reveal(),
-            $this->sampler->reveal(),
-            new HttpHeaderPropagator(),
-            [
-                'headers' => [
-                    'REQUEST_URI' => '/some/uri',
-                    'REQUEST_METHOD' => 'POST',
-                    'SERVER_PROTOCOL' => 'HTTP/1.1',
-                    'HTTP_USER_AGENT' => 'test agent 0.1',
-                    'HTTP_HOST' => 'example.com:8080',
-                    'GAE_SERVICE' => 'test_app',
-                    'GAE_VERSION' => 'some_version'
-                ]
-            ]
-        );
-        $span = $rt->tracer()->spans()[0];
-        $labels = $span->info()['labels'];
-        $expectedLabels = [
-            '/http/url' => '/some/uri',
-            '/http/method' => 'POST',
-            '/http/client_protocol' => 'HTTP/1.1',
-            '/http/user_agent' => 'test agent 0.1',
-            '/http/host' => 'example.com:8080',
-            'g.co/gae/app/module' => 'test_app',
-            'g.co/gae/app/module_version' => 'some_version'
-        ];
-
-        foreach ($expectedLabels as $key => $value) {
-            $this->assertArrayHasKey($key, $labels);
-            $this->assertEquals($value, $labels[$key]);
-        }
-        $this->assertArrayHasKey('/pid', $labels);
-        $this->assertArrayHasKey('/agent', $labels);
-        $version = trim(file_get_contents(__DIR__ .'/../../../src/VERSION'));
-        $this->assertEquals('opencensus '. $version, $labels['/agent']);
-    }
-
     public function testCanParseParentContext()
     {
         $rt = new RequestHandler(


### PR DESCRIPTION
Provides the `ReporterInterface` implementation for reporting to Stackdriver Trace.

Also moves Stackdriver specific label detection into the reporter (calculated before reporting and added to the root span).