### PR TITLE
Add ZipkinReporter

### DIFF
--- a/src/Trace/Reporter/ZipkinReporter.php
+++ b/src/Trace/Reporter/ZipkinReporter.php
@@ -109,8 +109,13 @@ class ZipkinReporter implements ReporterInterface
             array_map(function ($span) use ($traceId, $endpoint) {
                 $startTime = (int) $span->startTime() * 1000 * 1000;
                 $endTime = (int) $span->endTime() * 1000 * 1000;
+                $spanId = str_pad(dechex($span->spanId()), 16, '0', STR_PAD_LEFT);
+                $parentSpanId = $span->parentSpanId()
+                    ? str_pad(dechex($span->parentSpanId()), 16, '0', STR_PAD_LEFT)
+                    : null;
                 return [
-                    'id' => $span->spanId(),
+                    // 8-byte identifier encoded as 16 lowercase hex characters
+                    'id' => $spanId,
                     'traceId' => $traceId,
                     'name' => $span->name(),
                     'timestamp' => $startTime,
@@ -133,9 +138,11 @@ class ZipkinReporter implements ReporterInterface
                             'value' => $value
                         ];
                     }, $span->labels()),
-                    'parentId' => $span->parentId()
+                    'parentId' => $parentSpanId
                 ];
-            }, $spans);
+            }, $spans)
         );
     }
+
+    public function serializeSpan(TraceSpan $span)
 }

--- a/src/Trace/Reporter/ZipkinReporter.php
+++ b/src/Trace/Reporter/ZipkinReporter.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Reporter;
+
+use OpenCensus\Trace\Tracer\TracerInterface;
+
+/**
+ * This implementation of the ReporterInterface appends a json
+ * representation of the trace to a file.
+ */
+class ZipkinReporter implements ReporterInterface
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $host;
+
+    /**
+     * @var int
+     */
+    private $port;
+
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * Create a new ZipkinReporter
+     *
+     * @param string $name The name of this application
+     * @param string $host The hostname of the Zipkin server
+     * @param int $port The port of the Zipkin server
+     * @param string $endpoint (optional) The path for the span reporting endpoint. **Defaults to** `/api/v1/spans`
+     */
+    public function __construct($name, $host, $port, $endpoint = '/api/v1/spans')
+    {
+        $this->name = $name;
+        $this->host = $host;
+        $this->port = $port;
+        $this->url = "http://#{$host}:${port}${endpoint}";
+    }
+
+    /**
+     * Report the provided Trace to a backend.
+     *
+     * @param  TracerInterface $tracer
+     * @return bool
+     */
+    public function report(TracerInterface $tracer)
+    {
+        try {
+            $json = $this->serialize($tracer);
+            $contextOptions = [
+                'http' => [
+                    'method' => 'POST',
+                    'header' => 'Content-Type: application/json',
+                    'content' => $json
+                ]
+            ];
+
+            $context = stream_context_create($contextOptions);
+            file_get_contents($this->url, false, $context);
+        } catch (\Exception $e) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Serialize into Zipkin's expected JSON output format.
+     *
+     * @param  TracerInterface $tracer
+     * @return string JSON representation of the collected trace spans
+     */
+    public function serialize(TracerInterface $tracer)
+    {
+        $spans = $tracer->spans();
+        $context = $tracer->context();
+        $traceId = $context->traceId();
+
+        $endpoint = [
+            'ipv4' => $this->host,
+            'port' => $this->port,
+            'serviceName' => $this->name
+        ];
+
+        return json_encode(
+            array_map(function ($span) use ($traceId, $endpoint) {
+                $startTime = (int) $span->startTime() * 1000 * 1000;
+                $endTime = (int) $span->endTime() * 1000 * 1000;
+                return [
+                    'id' => $span->spanId(),
+                    'traceId' => $traceId,
+                    'name' => $span->name(),
+                    'timestamp' => $startTime,
+                    'duration' => $endTime - $startTime,
+                    'annotations' => [
+                        [
+                            'endpoint' => $endpoint,
+                            'timestamp' => $startTime,
+                            'value' => 'cs'
+                        ],
+                        [
+                            'endpoint' => $endpoint,
+                            'timestamp' => $endTime,
+                            'value' => 'cr'
+                        ]
+                    ],
+                    'binaryAnnotations' => array_map(function ($key, $value) {
+                        return [
+                            'key' => $key,
+                            'value' => $value
+                        ];
+                    }, $span->labels()),
+                    'parentId' => $span->parentId()
+                ];
+            }, $spans);
+        );
+    }
+}

--- a/src/Trace/Reporter/ZipkinReporter.php
+++ b/src/Trace/Reporter/ZipkinReporter.php
@@ -107,8 +107,8 @@ class ZipkinReporter implements ReporterInterface
 
         return json_encode(
             array_map(function ($span) use ($traceId, $endpoint) {
-                $startTime = (int) $span->startTime() * 1000 * 1000;
-                $endTime = (int) $span->endTime() * 1000 * 1000;
+                $startTime = (int)((float) $span->startTime()->format('U.u') * 1000 * 1000);
+                $endTime = (int)((float) $span->endTime()->format('U.u') * 1000 * 1000);
                 $spanId = str_pad(dechex($span->spanId()), 16, '0', STR_PAD_LEFT);
                 $parentSpanId = $span->parentSpanId()
                     ? str_pad(dechex($span->parentSpanId()), 16, '0', STR_PAD_LEFT)

--- a/src/Trace/Reporter/ZipkinReporter.php
+++ b/src/Trace/Reporter/ZipkinReporter.php
@@ -143,6 +143,4 @@ class ZipkinReporter implements ReporterInterface
             }, $spans)
         );
     }
-
-    public function serializeSpan(TraceSpan $span)
 }

--- a/src/Trace/Reporter/ZipkinReporter.php
+++ b/src/Trace/Reporter/ZipkinReporter.php
@@ -58,7 +58,7 @@ class ZipkinReporter implements ReporterInterface
         $this->name = $name;
         $this->host = $host;
         $this->port = $port;
-        $this->url = "http://#{$host}:${port}${endpoint}";
+        $this->url = "http://${host}:${port}${endpoint}";
     }
 
     /**
@@ -137,7 +137,7 @@ class ZipkinReporter implements ReporterInterface
                             'key' => $key,
                             'value' => $value
                         ];
-                    }, $span->labels()),
+                    }, array_keys($span->labels()), $span->labels()),
                     'parentId' => $parentSpanId
                 ];
             }, $spans)

--- a/src/Trace/TraceSpan.php
+++ b/src/Trace/TraceSpan.php
@@ -43,7 +43,7 @@ class TraceSpan implements \JsonSerializable
      * @param array $options [optional] {
      *      Configuration options.
      *
-     *      @type string $spanId The ID of the span. If not provided,
+     *      @type int $spanId The ID of the span. If not provided,
      *            one will be generated automatically for you.
      *      @type string $kind Distinguishes between spans generated
      *            in a particular context. **Defaults to**
@@ -94,6 +94,16 @@ class TraceSpan implements \JsonSerializable
         if (array_key_exists('parentSpanId', $options)) {
             $this->info['parentSpanId'] = $options['parentSpanId'];
         }
+    }
+
+    public function startTime()
+    {
+        return $this->info['startTime'];
+    }
+
+    public function endTime()
+    {
+        return $this->info['endTime'];
     }
 
     /**
@@ -150,6 +160,11 @@ class TraceSpan implements \JsonSerializable
     public function name()
     {
         return $this->info['name'];
+    }
+
+    public function labels()
+    {
+        return $this->info['labels'] ?: [];
     }
 
     /**
@@ -227,11 +242,11 @@ class TraceSpan implements \JsonSerializable
      * Generate a random ID for this span. Must be unique per trace,
      * but does not need to be globally unique.
      *
-     * @return string
+     * @return int
      */
     private function generateSpanId()
     {
-        return '' . mt_rand();
+        return mt_rand();
     }
 
     /**

--- a/src/Trace/TraceSpan.php
+++ b/src/Trace/TraceSpan.php
@@ -165,9 +165,16 @@ class TraceSpan
         return $this->info['name'];
     }
 
+    /**
+     * Retrieve the list of labels for this span
+     *
+     * @return array
+     */
     public function labels()
     {
-        return $this->info['labels'] ?: [];
+        return array_key_exists('labels', $this->info)
+            ? $this->info['labels']
+            : [];
     }
 
     /**

--- a/src/Trace/TraceSpan.php
+++ b/src/Trace/TraceSpan.php
@@ -99,16 +99,6 @@ class TraceSpan
         return $this->info['startTime'];
     }
 
-    public function startTime()
-    {
-        return $this->info['startTime'];
-    }
-
-    public function endTime()
-    {
-        return $this->info['endTime'];
-    }
-
     /**
      * Set the start time for this span.
      *

--- a/tests/unit/Trace/Reporter/ZipkinReporterTest.php
+++ b/tests/unit/Trace/Reporter/ZipkinReporterTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Unit\Trace\Reporter;
+
+use OpenCensus\Trace\Reporter\ZipkinReporter;
+use OpenCensus\Trace\TraceContext;
+use OpenCensus\Trace\TraceSpan;
+use OpenCensus\Trace\Tracer\TracerInterface;
+use Prophecy\Argument;
+
+/**
+ * @group trace
+ */
+class LoggerReporterTest extends \PHPUnit_Framework_TestCase
+{
+    private $tracer;
+
+    public function setUp()
+    {
+        $this->tracer = $this->prophesize(TracerInterface::class);
+    }
+
+    /**
+     * http://zipkin.io/zipkin-api/#/paths/%252Fspans/post
+     */
+    public function testFormatsTrace()
+    {
+        $spans = [
+            new TraceSpan([
+                'name' => 'span',
+                'startTime' => microtime(true),
+                'endTime' => microtime(true) + 10
+            ])
+        ];
+        $this->tracer->context()->willReturn(new TraceContext());
+        $this->tracer->spans()->willReturn($spans);
+
+        $reporter = new ZipkinReporter('myapp', 'localhost', 9411);
+
+        $json = $reporter->serialize($this->tracer->reveal());
+        $data = json_decode($json, true);
+
+        $this->assertInternalType('array', $data);
+        foreach ($data as $span) {
+            $this->assertRegExp('/[0-9a-z]{16}/', $span['id']);
+            $this->assertRegExp('/[0-9a-z]{32}/', $span['traceId']);
+            $this->assertInternalType('string', $span['name']);
+            $this->assertInternalType('int', $span['timestamp']);
+            $this->assertInternalType('int', $span['duration']);
+            $this->assertInternalType('array', $span['annotations']);
+            foreach ($span['annotations'] as $annotation) {
+                $this->assertInternalType('array', $annotation['endpoint']);
+                $this->assertInternalType('string', $annotation['endpoint']['ipv4']);
+                $this->assertInternalType('int', $annotation['endpoint']['port']);
+                $this->assertInternalType('string', $annotation['endpoint']['serviceName']);
+                $this->assertInternalType('int', $annotation['timestamp']);
+                $this->assertInternalType('string', $annotation['value']);
+            }
+            $this->assertInternalType('array', $span['binaryAnnotations']);
+            foreach ($span['binaryAnnotations'] as $annotation) {
+                $this->assertInternalType('string', $annotation['key']);
+                $this->assertInternalType('string', $annotation['value']);
+            }
+        }
+    }
+}

--- a/tests/unit/Trace/Reporter/ZipkinReporterTest.php
+++ b/tests/unit/Trace/Reporter/ZipkinReporterTest.php
@@ -26,7 +26,7 @@ use Prophecy\Argument;
 /**
  * @group trace
  */
-class LoggerReporterTest extends \PHPUnit_Framework_TestCase
+class ZipkinReporterTest extends \PHPUnit_Framework_TestCase
 {
     private $tracer;
 


### PR DESCRIPTION
This PR adds a `ZipkinReporter` which using built-in http streaming capabilities to report to a Zipkin (HTTP API)[http://zipkin.io/zipkin-api/#/paths/%252Fspans]. The reporter adapts the collected `TraceSpans` into the span format for Zipkin.

This was tested against a local Zipkin instance running in docker.