### PR TITLE
Simplify TraceSpan.

### DIFF
--- a/src/Trace/TraceSpan.php
+++ b/src/Trace/TraceSpan.php
@@ -90,6 +90,16 @@ class TraceSpan
     }
 
     /**
+     * Retrieve the start time for this span.
+     *
+     * @return \DateTimeInterface
+     */
+    public function startTime()
+    {
+        return $this->info['startTime'];
+    }
+
+    /**
      * Set the start time for this span.
      *
      * @param  \DateTimeInterface|int|float|string $when [optional] The start time of this span.
@@ -99,6 +109,16 @@ class TraceSpan
     public function setStartTime($when = null)
     {
         $this->info['startTime'] = $this->formatDate($when);
+    }
+
+    /**
+     * Retrieve the end time for this span.
+     *
+     * @return \DateTimeInterface
+     */
+    public function endTime()
+    {
+        return $this->info['endTime'];
     }
 
     /**
@@ -187,7 +207,7 @@ class TraceSpan
      * @param  \DateTimeInterface|int|float $when [optional] The end time of this span.
      *         **Defaults to** now. If provided as a string, it must be in "Zulu" format.
      *         If provided as an int or float, it is expected to be a Unix timestamp.
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     private function formatDate($when = null)
     {

--- a/src/Trace/TraceSpan.php
+++ b/src/Trace/TraceSpan.php
@@ -18,36 +18,27 @@
 namespace OpenCensus\Trace;
 
 /**
- * This plain PHP class represents a
- * [TraceSpan resource](https://cloud.google.com/trace/docs/reference/v1/rest/v1/projects.traces#TraceSpan)
- * A span represents a single timed event within a Trace. Spans can be nested
- * and form a trace tree. Often, a trace contains a root span that describes
- * the end-to-end latency of an operation and, optionally, one or more subspans
+ * This plain PHP class represents a single timed event within a Trace. Spans can
+ * be nested and form a trace tree. Often, a trace contains a root span that
+ * describes the end-to-end latency of an operation and, optionally, one or more subspans
  * for its suboperations. Spans do not need to be contiguous. There may be
  * gaps between spans in a trace.
  */
-class TraceSpan implements \JsonSerializable
+class TraceSpan
 {
-    const SPAN_KIND_UNSPECIFIED = 'SPAN_KIND_UNSPECIFIED';
-    const SPAN_KIND_RPC_SERVER = 'RPC_SERVER';
-    const SPAN_KIND_RPC_CLIENT = 'RPC_CLIENT';
-
     /**
-     * @var array Associative array containing all the fields representing this TraceSpan.
+     * @var array Associative array containing all the fields representing this Span.
      */
     private $info = [];
 
     /**
-     * Instantiate a new TraceSpan instance.
+     * Instantiate a new Span instance.
      *
      * @param array $options [optional] {
      *      Configuration options.
      *
      *      @type string $spanId The ID of the span. If not provided,
      *            one will be generated automatically for you.
-     *      @type string $kind Distinguishes between spans generated
-     *            in a particular context. **Defaults to**
-     *            SPAN_KIND_UNSPECIFIED.
      *      @type string $name The name of the span.
      *      @type \DateTimeInterface|int|float|string $startTime Start time of the span in nanoseconds.
      *            If provided as a string, it must be in "Zulu" format. If provided as an int or float, it is
@@ -63,37 +54,39 @@ class TraceSpan implements \JsonSerializable
     public function __construct($options = [])
     {
         if (array_key_exists('startTime', $options)) {
-            $this->setStart($options['startTime']);
+            $this->setStartTime($options['startTime']);
+            unset($options['startTime']);
         }
         if (array_key_exists('endTime', $options)) {
-            $this->setEnd($options['endTime']);
+            $this->setEndTime($options['endTime']);
+            unset($options['endTime']);
         }
 
         if (array_key_exists('labels', $options)) {
             $this->addLabels($options['labels']);
+            unset($options['labels']);
         }
 
         if (array_key_exists('spanId', $options)) {
             $this->info['spanId'] = $options['spanId'];
+            unset($options['spanId']);
         } else {
             $this->info['spanId'] = $this->generateSpanId();
         }
 
-        if (array_key_exists('kind', $options)) {
-            $this->info['kind'] = $options['kind'];
-        } else {
-            $this->info['kind'] = self::SPAN_KIND_UNSPECIFIED;
-        }
-
         if (array_key_exists('name', $options)) {
             $this->info['name'] = $options['name'];
+            unset($options['name']);
         } else {
             $this->info['name'] = $this->generateSpanName();
         }
 
         if (array_key_exists('parentSpanId', $options)) {
             $this->info['parentSpanId'] = $options['parentSpanId'];
+            unset($options['parentSpanId']);
         }
+
+        $this->info['metadata'] = $options;
     }
 
     /**
@@ -103,7 +96,7 @@ class TraceSpan implements \JsonSerializable
      *         **Defaults to** now. If provided as a string, it must be in "Zulu" format.
      *         If provided as an int or float, it is expected to be a Unix timestamp.
      */
-    public function setStart($when = null)
+    public function setStartTime($when = null)
     {
         $this->info['startTime'] = $this->formatDate($when);
     }
@@ -115,7 +108,7 @@ class TraceSpan implements \JsonSerializable
      *         **Defaults to** now. If provided as a string, it must be in "Zulu" format.
      *         If provided as an int or float, it is expected to be a Unix timestamp.
      */
-    public function setEnd($when = null)
+    public function setEndTime($when = null)
     {
         $this->info['endTime'] = $this->formatDate($when);
     }
@@ -163,16 +156,6 @@ class TraceSpan implements \JsonSerializable
     }
 
     /**
-     * Returns the info array for serialization.
-     *
-     * @return array
-     */
-    public function jsonSerialize()
-    {
-        return $this->info;
-    }
-
-    /**
      * Attach labels to this span.
      *
      * @param array $labels Labels in the form of $label => $value
@@ -201,16 +184,15 @@ class TraceSpan implements \JsonSerializable
     /**
      * Returns a "Zulu" formatted string representing the provided \DateTime.
      *
-     * @param  \DateTimeInterface|int|float|string $when [optional] The end time of this span.
+     * @param  \DateTimeInterface|int|float $when [optional] The end time of this span.
      *         **Defaults to** now. If provided as a string, it must be in "Zulu" format.
      *         If provided as an int or float, it is expected to be a Unix timestamp.
-     * @return string
+     * @return \DateTime
      */
     private function formatDate($when = null)
     {
-        if (is_string($when)) {
-            return $when;
-        } elseif (!$when) {
+        if (!$when) {
+            // now
             list($usec, $sec) = explode(' ', microtime());
             $micro = sprintf("%06d", $usec * 1000000);
             $when = new \DateTime(date('Y-m-d H:i:s.' . $micro));
@@ -218,9 +200,11 @@ class TraceSpan implements \JsonSerializable
             // Expect that this is a timestamp
             $micro = sprintf("%06d", ($when - floor($when)) * 1000000);
             $when = new \DateTime(date('Y-m-d H:i:s.'. $micro, (int) $when));
+        } elseif (!$when instanceof \DateTimeInterface) {
+            throw new \InvalidArgumentException('Invalid date format. Must be a \DateTimeInterface or numeric.');
         }
         $when->setTimezone(new \DateTimeZone('UTC'));
-        return $when->format('Y-m-d\TH:i:s.u000\Z');
+        return $when;
     }
 
     /**

--- a/src/Trace/TraceSpan.php
+++ b/src/Trace/TraceSpan.php
@@ -37,7 +37,7 @@ class TraceSpan
      * @param array $options [optional] {
      *      Configuration options.
      *
-     *      @type string $spanId The ID of the span. If not provided,
+     *      @type int $spanId The ID of the span. If not provided,
      *            one will be generated automatically for you.
      *      @type string $name The name of the span.
      *      @type \DateTimeInterface|int|float|string $startTime Start time of the span in nanoseconds.
@@ -46,7 +46,7 @@ class TraceSpan
      *      @type \DateTimeInterface|int|float|string $endTime End time of the span in nanoseconds.
      *            If provided as a string, it must be in "Zulu" format. If provided as an int or float, it is
      *            expected to be a Unix timestamp.
-     *      @type string $parentSpanId ID of the parent span if any.
+     *      @type int $parentSpanId ID of the parent span if any.
      *      @type array $labels Associative array of $label => $value
      *            to attach to this span.
      * }
@@ -116,7 +116,7 @@ class TraceSpan
     /**
      * Retrieve the ID of this span.
      *
-     * @return string
+     * @return int
      */
     public function spanId()
     {
@@ -126,7 +126,7 @@ class TraceSpan
     /**
      * Retrieve the ID of this span's parent if it exists.
      *
-     * @return string
+     * @return int
      */
     public function parentSpanId()
     {
@@ -211,11 +211,11 @@ class TraceSpan
      * Generate a random ID for this span. Must be unique per trace,
      * but does not need to be globally unique.
      *
-     * @return string
+     * @return int
      */
     private function generateSpanId()
     {
-        return '' . mt_rand();
+        return mt_rand();
     }
 
     /**

--- a/src/Trace/Tracer/ContextTracer.php
+++ b/src/Trace/Tracer/ContextTracer.php
@@ -101,7 +101,7 @@ class ContextTracer implements TracerInterface
         $span = array_shift($this->stack);
         $this->context->setSpanId(empty($this->stack) ? null : $this->stack[0]->spanId());
         if ($span) {
-            $span->setEnd();
+            $span->setEndTime();
             return true;
         }
         return false;

--- a/tests/unit/Trace/TraceSpanTest.php
+++ b/tests/unit/Trace/TraceSpanTest.php
@@ -94,35 +94,19 @@ class TraceSpanTest extends \PHPUnit_Framework_TestCase
     public function testStartFormat()
     {
         $traceSpan = new TraceSpan();
-        $traceSpan->setStart();
+        $traceSpan->setStartTime();
         $info = $traceSpan->info();
         $this->assertArrayHasKey('startTime', $info);
-        $this->assertRegExp(self::EXPECTED_TIMESTAMP_FORMAT, $info['startTime']);
+        $this->assertInstanceOf(\DateTimeInterface::class, $info['startTime']);
     }
 
     public function testFinishFormat()
     {
         $traceSpan = new TraceSpan();
-        $traceSpan->setEnd();
+        $traceSpan->setEndTime();
         $info = $traceSpan->info();
         $this->assertArrayHasKey('endTime', $info);
-        $this->assertRegExp(self::EXPECTED_TIMESTAMP_FORMAT, $info['endTime']);
-    }
-
-    public function testGeneratesDefaultKind()
-    {
-        $traceSpan = new TraceSpan();
-        $info = $traceSpan->info();
-        $this->assertArrayHasKey('kind', $info);
-        $this->assertEquals(TraceSpan::SPAN_KIND_UNSPECIFIED, $info['kind']);
-    }
-
-    public function testReadsKind()
-    {
-        $traceSpan = new TraceSpan(['kind' => TraceSpan::SPAN_KIND_RPC_CLIENT]);
-        $info = $traceSpan->info();
-        $this->assertArrayHasKey('kind', $info);
-        $this->assertEquals(TraceSpan::SPAN_KIND_RPC_CLIENT, $info['kind']);
+        $this->assertInstanceOf(\DateTimeInterface::class, $info['endTime']);
     }
 
     public function testIgnoresUnknownFields()
@@ -138,7 +122,7 @@ class TraceSpanTest extends \PHPUnit_Framework_TestCase
     public function testCanFormatTimestamps($field, $timestamp, $expected)
     {
         $traceSpan = new TraceSpan([$field => $timestamp]);
-        $this->assertEquals($expected, $traceSpan->info()[$field]);
+        $this->assertEquals($expected, $traceSpan->info()[$field]->format('Y-m-d\TH:i:s.u000\Z'));
     }
 
     public function timestampFields()
@@ -146,10 +130,8 @@ class TraceSpanTest extends \PHPUnit_Framework_TestCase
         return [
             ['startTime', 1490737410, '2017-03-28T21:43:30.000000000Z'],
             ['startTime', 1490737450.4843, '2017-03-28T21:44:10.484299000Z'],
-            ['startTime', '2017-03-28T21:44:10.484299000Z', '2017-03-28T21:44:10.484299000Z'],
             ['endTime', 1490737410, '2017-03-28T21:43:30.000000000Z'],
             ['endTime', 1490737450.4843, '2017-03-28T21:44:10.484299000Z'],
-            ['endTime', '2017-03-28T21:44:10.484299000Z', '2017-03-28T21:44:10.484299000Z'],
         ];
     }
 }

--- a/tests/unit/Trace/TraceSpanTest.php
+++ b/tests/unit/Trace/TraceSpanTest.php
@@ -31,7 +31,6 @@ class TraceSpanTest extends \PHPUnit_Framework_TestCase
         $traceSpan = new TraceSpan();
         $info = $traceSpan->info();
         $this->assertArrayHasKey('spanId', $info);
-        $this->assertRegExp('/^\d+$/', $info['spanId']);
         $this->assertEquals($info['spanId'], $traceSpan->spanId());
     }
 

--- a/tests/unit/Trace/TraceTest.php
+++ b/tests/unit/Trace/TraceTest.php
@@ -25,7 +25,10 @@ use OpenCensus\Trace\TraceSpan;
  */
 class TraceTest extends \PHPUnit_Framework_TestCase
 {
-    public function testLoadFromArray()
+    /**
+     * @dataProvider dateFormats
+     */
+    public function testLoadFromArray($date)
     {
         $trace = new Trace(
             '1234abcd',
@@ -34,8 +37,8 @@ class TraceTest extends \PHPUnit_Framework_TestCase
                     'spanId' => '12345',
                     'kind' => 'SPAN_KIND_UNSPECIFIED',
                     'name' => 'spanname',
-                    'startTime' => 1490737450.4843,
-                    'endTime' => 1490737450.4843
+                    'startTime' => $date,
+                    'endTime' => $date
                 ]
             ]
         );
@@ -43,6 +46,8 @@ class TraceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($trace->spans()));
         foreach($trace->spans() as $span) {
             $this->assertInstanceOf(TraceSpan::class, $span);
+            $this->assertInstanceOf(\DateTimeInterface::class, $span->startTime());
+            $this->assertInstanceOf(\DateTimeInterface::class, $span->endTime());
         }
     }
 
@@ -64,5 +69,13 @@ class TraceTest extends \PHPUnit_Framework_TestCase
     {
         $trace = new Trace('1', [['name' => 'main']]);
         $trace->info();
+    }
+
+    public function dateFormats()
+    {
+        return [
+            [1490737450.4843],
+            [new \DateTime()]
+        ];
     }
 }

--- a/tests/unit/Trace/TraceTest.php
+++ b/tests/unit/Trace/TraceTest.php
@@ -34,8 +34,8 @@ class TraceTest extends \PHPUnit_Framework_TestCase
                     'spanId' => '12345',
                     'kind' => 'SPAN_KIND_UNSPECIFIED',
                     'name' => 'spanname',
-                    'startTime' => '2017-03-28T21:44:10.484299000Z',
-                    'endTime' => '2017-03-28T21:44:11.123456000Z'
+                    'startTime' => 1490737450.4843,
+                    'endTime' => 1490737450.4843
                 ]
             ]
         );


### PR DESCRIPTION
Kind is now optional and stored in a metadata array.
Start and end times are stored as `\DateTime` objects.
Also disallows providing a string formatted start/end time for creating a `TraceSpan`. These are not loaded from an API call so the string format doesn't make sense to support.

This is necessary because different reporters handle the start and end time formats differently. Zipkin uses an integer representing microseconds while Stackdriver Trace uses a Zulu formatted timestamp string.