### PR TITLE
Add trace integrations

### DIFF
--- a/src/Trace/Integrations/Curl.php
+++ b/src/Trace/Integrations/Curl.php
@@ -38,14 +38,16 @@ class Curl implements IntegrationInterface
             return;
         }
 
-        opencensus_trace_function('curl_exec', function ($resource) {
-            return [
-                'labels' => [
-                    'uri' => curl_getinfo($resource, CURLINFO_EFFECTIVE_URL)
-                ]
-            ];
-        });
+        opencensus_trace_function('curl_exec', [self, 'handleCurlResource']);
         opencensus_trace_function('curl_multi_add_handle');
         opencensus_trace_function('curl_multi_remove_handle');
+    }
+
+    public static function handleCurlResource($resource) {
+        return [
+            'labels' => [
+                'uri' => curl_getinfo($resource, CURLINFO_EFFECTIVE_URL)
+            ]
+        ];
     }
 }

--- a/src/Trace/Integrations/Curl.php
+++ b/src/Trace/Integrations/Curl.php
@@ -38,11 +38,17 @@ class Curl implements IntegrationInterface
             return;
         }
 
-        opencensus_trace_function('curl_exec', [self, 'handleCurlResource']);
+        opencensus_trace_function('curl_exec', [static::class, 'handleCurlResource']);
         opencensus_trace_function('curl_multi_add_handle');
         opencensus_trace_function('curl_multi_remove_handle');
     }
 
+    /**
+     * Handle extracting the uri from a given curl resource handler
+     *
+     * @param resource $resource The curl handler
+     * @return array
+     */
     public static function handleCurlResource($resource) {
         return [
             'labels' => [

--- a/src/Trace/Integrations/Curl.php
+++ b/src/Trace/Integrations/Curl.php
@@ -38,14 +38,14 @@ class Curl implements IntegrationInterface
             return;
         }
 
-        opencensus_function('curl_exec', function ($resource) {
+        opencensus_trace_function('curl_exec', function ($resource) {
             return [
                 'labels' => [
                     'uri' => curl_getinfo($resource, CURLINFO_EFFECTIVE_URL)
                 ]
             ];
         });
-        opencensus_function('curl_multi_add_handle');
-        opencensus_function('curl_multi_remove_handle');
+        opencensus_trace_function('curl_multi_add_handle');
+        opencensus_trace_function('curl_multi_remove_handle');
     }
 }

--- a/src/Trace/Integrations/Curl.php
+++ b/src/Trace/Integrations/Curl.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+/**
+ * This class handles instrumenting curl requests using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Curl
+ *
+ * Curl::load();
+ * ```
+ */
+class Curl implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to curl requests
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        opencensus_function('curl_exec', function ($resource) {
+            return [
+                'labels' => [
+                    'uri' => curl_getinfo($resource, CURLINFO_EFFECTIVE_URL)
+                ]
+            ];
+        });
+        opencensus_function('curl_multi_add_handle');
+        opencensus_function('curl_multi_remove_handle');
+    }
+}

--- a/src/Trace/Integrations/Curl.php
+++ b/src/Trace/Integrations/Curl.php
@@ -49,7 +49,8 @@ class Curl implements IntegrationInterface
      * @param resource $resource The curl handler
      * @return array
      */
-    public static function handleCurlResource($resource) {
+    public static function handleCurlResource($resource)
+    {
         return [
             'labels' => [
                 'uri' => curl_getinfo($resource, CURLINFO_EFFECTIVE_URL)

--- a/src/Trace/Integrations/Curl.php
+++ b/src/Trace/Integrations/Curl.php
@@ -35,6 +35,7 @@ class Curl implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load curl integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Doctrine.php
+++ b/src/Trace/Integrations/Doctrine.php
@@ -31,7 +31,7 @@ use Doctrine\ORM\Version;
 class Doctrine implements IntegrationInterface
 {
     /**
-     * Static method to add instrumentation to the Symfony framework
+     * Static method to add instrumentation to Doctrine ORM calls
      */
     public static function load()
     {

--- a/src/Trace/Integrations/Doctrine.php
+++ b/src/Trace/Integrations/Doctrine.php
@@ -47,7 +47,7 @@ class Doctrine implements IntegrationInterface
 
         // public function load(array $criteria, $entity = null, $assoc = null, array $hints = array(),
         //      $lockMode = null, $limit = null, array $orderBy = null)
-        opencensus_method($persisterClass, 'load', function ($bep) {
+        opencensus_trace_method($persisterClass, 'load', function ($bep) {
             return [
                 'name' => 'doctrine/load',
                 'labels' => ['entity' => $bep->getClassMetadata()->name]
@@ -55,7 +55,7 @@ class Doctrine implements IntegrationInterface
         });
 
         // public function loadAll(array $criteria = array(), array $orderBy = null, $limit = null, $offset = null)
-        opencensus_method($persisterClass, 'loadAll', function ($bep) {
+        opencensus_trace_method($persisterClass, 'loadAll', function ($bep) {
             return [
                 'name' => 'doctrine/loadAll',
                 'labels' => ['entity' => $bep->getClassMetadata()->name]
@@ -63,7 +63,7 @@ class Doctrine implements IntegrationInterface
         });
 
         // public int PDOConnection::exec(string $query)
-        opencensus_method(PDOConnection::class, 'exec', function ($scope, $query) {
+        opencensus_trace_method(PDOConnection::class, 'exec', function ($scope, $query) {
             return [
                 'name' => 'doctrine/exec',
                 'labels' => ['query' => $query]

--- a/src/Trace/Integrations/Doctrine.php
+++ b/src/Trace/Integrations/Doctrine.php
@@ -36,6 +36,7 @@ class Doctrine implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load Doctrine integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Doctrine.php
+++ b/src/Trace/Integrations/Doctrine.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+use Doctrine\ORM\Version;
+
+/**
+ * This class handles instrumenting the Doctrine ORM queries using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Doctrine
+ *
+ * Doctrine::load();
+ */
+class Doctrine implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to the Symfony framework
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        PDO::load();
+
+        $persisterClass = (Version::compare('2.5.0') < 0)
+            ? 'Doctrine\ORM\Persisters\Entity\BasicEntityPersister'    // Doctrine 2.5 or greater
+            : 'Doctrine\ORM\Persisters\BasicEntityPersister';          // Doctrine 2.4 or earlier
+
+        // public function load(array $criteria, $entity = null, $assoc = null, array $hints = array(),
+        //      $lockMode = null, $limit = null, array $orderBy = null)
+        opencensus_method($persisterClass, 'load', function ($bep) {
+            return [
+                'name' => 'doctrine/load',
+                'labels' => ['entity' => $bep->getClassMetadata()->name]
+            ];
+        });
+
+        // public function loadAll(array $criteria = array(), array $orderBy = null, $limit = null, $offset = null)
+        opencensus_method($persisterClass, 'loadAll', function ($bep) {
+            return [
+                'name' => 'doctrine/loadAll',
+                'labels' => ['entity' => $bep->getClassMetadata()->name]
+            ];
+        });
+
+        // public int PDOConnection::exec(string $query)
+        opencensus_method(PDOConnection::class, 'exec', function ($scope, $query) {
+            return [
+                'name' => 'doctrine/exec',
+                'labels' => ['query' => $query]
+            ];
+        });
+    }
+}

--- a/src/Trace/Integrations/Eloquent.php
+++ b/src/Trace/Integrations/Eloquent.php
@@ -37,6 +37,7 @@ class Eloquent implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load Eloquent integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Eloquent.php
+++ b/src/Trace/Integrations/Eloquent.php
@@ -41,7 +41,7 @@ class Eloquent implements IntegrationInterface
         }
 
         // public function getModels($columns = ['*'])
-        opencensus_method(Builder::class, 'getModels', function ($scope, $columns) {
+        opencensus_trace_method(Builder::class, 'getModels', function ($scope, $columns) {
             // Builder class has $model property but it's protected - use reflection to read the property
             $reflection = new \ReflectionClass(Builder::class);
             $modelProperty = $reflection->getProperty('model');
@@ -57,7 +57,7 @@ class Eloquent implements IntegrationInterface
         });
 
         // protected function performInsert(Builder $query)
-        opencensus_method(Model::class, 'performInsert', function ($scope, $query) {
+        opencensus_trace_method(Model::class, 'performInsert', function ($scope, $query) {
             return [
                 'name' => 'eloquent/insert',
                 'labels' => [
@@ -67,7 +67,7 @@ class Eloquent implements IntegrationInterface
         });
 
         // protected function performUpdate(Builder $query)
-        opencensus_method(Model::class, 'performUpdate', function ($scope, $query) {
+        opencensus_trace_method(Model::class, 'performUpdate', function ($scope, $query) {
             return [
                 'name' => 'eloquent/update',
                 'labels' => [
@@ -77,7 +77,7 @@ class Eloquent implements IntegrationInterface
         });
 
         // public function delete()
-        opencensus_method(Model::class, 'delete', function ($scope, $query) {
+        opencensus_trace_method(Model::class, 'delete', function ($scope, $query) {
             return [
                 'name' => 'eloquent/delete',
                 'labels' => [

--- a/src/Trace/Integrations/Eloquent.php
+++ b/src/Trace/Integrations/Eloquent.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * This class handles instrumenting the Eloquent ORM queries using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Eloquent
+ *
+ * Eloquent::load();
+ */
+class Eloquent implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to the Symfony framework
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        // public function getModels($columns = ['*'])
+        opencensus_method(Builder::class, 'getModels', function ($scope, $columns) {
+            // Builder class has $model property but it's protected - use reflection to read the property
+            $reflection = new \ReflectionClass(Builder::class);
+            $modelProperty = $reflection->getProperty('model');
+            $modelProperty->setAccessible(true);
+            $model = $modelProperty->getValue($scope);
+
+            return [
+                'name' => 'eloquent/get',
+                'labels' => [
+                    'model' => get_class($model)
+                ]
+            ];
+        });
+
+        // protected function performInsert(Builder $query)
+        opencensus_method(Model::class, 'performInsert', function ($scope, $query) {
+            return [
+                'name' => 'eloquent/insert',
+                'labels' => [
+                    'model' => get_class($scope)
+                ]
+            ];
+        });
+
+        // protected function performUpdate(Builder $query)
+        opencensus_method(Model::class, 'performUpdate', function ($scope, $query) {
+            return [
+                'name' => 'eloquent/update',
+                'labels' => [
+                    'model' => get_class($scope)
+                ]
+            ];
+        });
+
+        // public function delete()
+        opencensus_method(Model::class, 'delete', function ($scope, $query) {
+            return [
+                'name' => 'eloquent/delete',
+                'labels' => [
+                    'model' => get_class($scope)
+                ]
+            ];
+        });
+    }
+}

--- a/src/Trace/Integrations/Eloquent.php
+++ b/src/Trace/Integrations/Eloquent.php
@@ -32,7 +32,7 @@ use Illuminate\Database\Eloquent\Model;
 class Eloquent implements IntegrationInterface
 {
     /**
-     * Static method to add instrumentation to the Symfony framework
+     * Static method to add instrumentation to Eloquent ORM calls
      */
     public static function load()
     {

--- a/src/Trace/Integrations/Eloquent.php
+++ b/src/Trace/Integrations/Eloquent.php
@@ -41,47 +41,41 @@ class Eloquent implements IntegrationInterface
         }
 
         // public function getModels($columns = ['*'])
-        opencensus_trace_method(Builder::class, 'getModels', function ($scope, $columns) {
-            // Builder class has $model property but it's protected - use reflection to read the property
-            $reflection = new \ReflectionClass(Builder::class);
-            $modelProperty = $reflection->getProperty('model');
-            $modelProperty->setAccessible(true);
-            $model = $modelProperty->getValue($scope);
-
+        opencensus_trace_method(Builder::class, 'getModels', function ($builder) {
             return [
                 'name' => 'eloquent/get',
                 'labels' => [
-                    'model' => get_class($model)
+                    'query' => $builder->toBase()->toSql()
                 ]
             ];
         });
 
         // protected function performInsert(Builder $query)
-        opencensus_trace_method(Model::class, 'performInsert', function ($scope, $query) {
+        opencensus_trace_method(Model::class, 'performInsert', function ($model, $query) {
             return [
                 'name' => 'eloquent/insert',
                 'labels' => [
-                    'model' => get_class($scope)
+                    'query' => $query->toBase()->toSql()
                 ]
             ];
         });
 
         // protected function performUpdate(Builder $query)
-        opencensus_trace_method(Model::class, 'performUpdate', function ($scope, $query) {
+        opencensus_trace_method(Model::class, 'performUpdate', function ($model, $query) {
             return [
                 'name' => 'eloquent/update',
                 'labels' => [
-                    'model' => get_class($scope)
+                    'query' => $query->toBase()->toSql()
                 ]
             ];
         });
 
         // public function delete()
-        opencensus_trace_method(Model::class, 'delete', function ($scope, $query) {
+        opencensus_trace_method(Model::class, 'delete', function ($model, $query) {
             return [
                 'name' => 'eloquent/delete',
                 'labels' => [
-                    'model' => get_class($scope)
+                    'query' => $query->toBase()->toSql()
                 ]
             ];
         });

--- a/src/Trace/Integrations/Grpc.php
+++ b/src/Trace/Integrations/Grpc.php
@@ -37,6 +37,7 @@ class Grpc implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load grpc integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Grpc.php
+++ b/src/Trace/Integrations/Grpc.php
@@ -42,7 +42,7 @@ class Grpc implements IntegrationInterface
 
         // protected function _simpleRequest($method, $argument, $deserialize, array $metadata = [],
         //                                   array $options = [])
-        opencensus_method(BaseStub::class, '_simpleRequest', function ($stub, $method) {
+        opencensus_trace_method(BaseStub::class, '_simpleRequest', function ($stub, $method) {
             return [
                 'name' => 'grpc/simpleRequest',
                 'labels' => [
@@ -54,7 +54,7 @@ class Grpc implements IntegrationInterface
 
         // protected function _clientStreamRequest($method, $argument, $deserialize, array $metadata = [],
         //                                         array $options = [])
-        opencensus_method(BaseStub::class, '_clientStreamRequest', function ($stub, $method) {
+        opencensus_trace_method(BaseStub::class, '_clientStreamRequest', function ($stub, $method) {
             return [
                 'name' => 'grpc/clientStreamRequest',
                 'labels' => [
@@ -66,7 +66,7 @@ class Grpc implements IntegrationInterface
 
         // protected function _serverStreamRequest($method, $argument, $deserialize, array $metadata = [],
         //                                         array $options = [])
-        opencensus_method(BaseStub::class, '_serverStreamRequest', function ($stub, $method) {
+        opencensus_trace_method(BaseStub::class, '_serverStreamRequest', function ($stub, $method) {
             return [
                 'name' => 'grpc/serverStreamRequest',
                 'labels' => [
@@ -77,7 +77,7 @@ class Grpc implements IntegrationInterface
         });
 
         // protected function _bidiRequest($method, $deserialize, array $metadata = [], array $options = [])
-        opencensus_method(BaseStub::class, '_bidiRequest', function ($stub, $method) {
+        opencensus_trace_method(BaseStub::class, '_bidiRequest', function ($stub, $method) {
             return [
                 'name' => 'grpc/bidiRequest',
                 'labels' => [

--- a/src/Trace/Integrations/Grpc.php
+++ b/src/Trace/Integrations/Grpc.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+use Grpc\BaseStub;
+
+/**
+ * This class handles instrumenting grpc requests using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Grpc
+ *
+ * Grpc::load();
+ * ```
+ */
+class Grpc implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to grpc requests
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        // protected function _simpleRequest($method, $argument, $deserialize, array $metadata = [],
+        //                                   array $options = [])
+        opencensus_method(BaseStub::class, '_simpleRequest', function ($stub, $method) {
+            return [
+                'name' => 'grpc/simpleRequest',
+                'labels' => [
+                    'host' => $stub->getTarget(),
+                    'uri' => $method
+                ]
+            ];
+        });
+
+        // protected function _clientStreamRequest($method, $argument, $deserialize, array $metadata = [],
+        //                                         array $options = [])
+        opencensus_method(BaseStub::class, '_clientStreamRequest', function ($stub, $method) {
+            return [
+                'name' => 'grpc/clientStreamRequest',
+                'labels' => [
+                    'host' => $stub->getTarget(),
+                    'uri' => $method
+                ]
+            ];
+        });
+
+        // protected function _serverStreamRequest($method, $argument, $deserialize, array $metadata = [],
+        //                                         array $options = [])
+        opencensus_method(BaseStub::class, '_serverStreamRequest', function ($stub, $method) {
+            return [
+                'name' => 'grpc/serverStreamRequest',
+                'labels' => [
+                    'host' => $stub->getTarget(),
+                    'uri' => $method
+                ]
+            ];
+        });
+
+        // protected function _bidiRequest($method, $deserialize, array $metadata = [], array $options = [])
+        opencensus_method(BaseStub::class, '_bidiRequest', function ($stub, $method) {
+            return [
+                'name' => 'grpc/bidiRequest',
+                'labels' => [
+                    'host' => $stub->getTarget(),
+                    'uri' => $method
+                ]
+            ];
+        });
+    }
+}

--- a/src/Trace/Integrations/Guzzle.php
+++ b/src/Trace/Integrations/Guzzle.php
@@ -61,7 +61,7 @@ class Guzzle implements IntegrationInterface
     protected static function loadGuzzle5()
     {
         // public function send(RequestInterface $request)
-        opencensus_method(Client::class, 'send', function ($scope, $request) {
+        opencensus_trace_method(Client::class, 'send', function ($scope, $request) {
             return [
                 'labels' => [
                     'method' => $request->getMethod(),
@@ -77,7 +77,7 @@ class Guzzle implements IntegrationInterface
     protected static function loadGuzzle6()
     {
         // public function send(RequestInterface $request, array $options = [])
-        opencensus_method(Client::class, 'send', function ($scope, $request) {
+        opencensus_trace_method(Client::class, 'send', function ($scope, $request) {
             return [
                 'labels' => [
                     'method' => $request->getMethod(),
@@ -87,7 +87,7 @@ class Guzzle implements IntegrationInterface
         });
 
         // public function request($method, $uri = '', array $options = [])
-        opencensus_method(Client::class, 'request', function ($scope, $method, $uri) {
+        opencensus_trace_method(Client::class, 'request', function ($scope, $method, $uri) {
             return [
                 'labels' => [
                     'method' => $method,

--- a/src/Trace/Integrations/Guzzle.php
+++ b/src/Trace/Integrations/Guzzle.php
@@ -39,6 +39,7 @@ class Guzzle implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load Guzzle integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Guzzle.php
+++ b/src/Trace/Integrations/Guzzle.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+
+/**
+ * This class handles instrumenting Guzzle http synchronous requests using the opencensus extension.
+ * Asynchronous requests are not instrumented because the work may be done outside of PHP via streams so
+ * any trace spans would be misleading.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Guzzle
+ *
+ * Guzzle::load();
+ */
+class Guzzle implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to Guzzle http synchronous requests
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        $version = ClientInterface::VERSION;
+        switch ($version[0]) {
+            case '5':
+                self::loadGuzzle5();
+                break;
+            case '6':
+                self::loadGuzzle6();
+                break;
+            default:
+                throw new \Exception("Version '$version' not supported");
+        }
+    }
+
+    /**
+     * Add Guzzle 5 specific integrations
+     */
+    protected static function loadGuzzle5()
+    {
+        // public function send(RequestInterface $request)
+        opencensus_method(Client::class, 'send', function ($scope, $request) {
+            return [
+                'labels' => [
+                    'method' => $request->getMethod(),
+                    'uri' => $request->getUrl()
+                ]
+            ];
+        });
+    }
+
+    /**
+     * Add Guzzle 6 specific integrations
+     */
+    protected static function loadGuzzle6()
+    {
+        // public function send(RequestInterface $request, array $options = [])
+        opencensus_method(Client::class, 'send', function ($scope, $request) {
+            return [
+                'labels' => [
+                    'method' => $request->getMethod(),
+                    'uri' => (string)$request->getUri()
+                ]
+            ];
+        });
+
+        // public function request($method, $uri = '', array $options = [])
+        opencensus_method(Client::class, 'request', function ($scope, $method, $uri) {
+            return [
+                'labels' => [
+                    'method' => $method,
+                    'uri' => $uri
+                ]
+            ];
+        });
+    }
+}

--- a/src/Trace/Integrations/Guzzle/EventSubscriber.php
+++ b/src/Trace/Integrations/Guzzle/EventSubscriber.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations\Guzzle;
+
+use OpenCensus\Trace\RequestTracer;
+use GuzzleHttp\Event\BeforeEvent;
+use GuzzleHttp\Event\EndEvent;
+use GuzzleHttp\Event\SubscriberInterface;
+
+/**
+ * This class handles integration with GuzzleHttp 5. Attaching this EventSubscriber to
+ * your Guzzle client, will enable distrubted tracing by passing along the trace context
+ * header and will also create trace spans for all outgoing requests.
+ *
+ * Example:
+ * ```
+ * use GuzzleHttp\Client;
+ * use OpenCensus\Trace\Integrations\Guzzle\EventSubscriber;
+ *
+ * $client = new Client();
+ * $subscriber = new EventSubscriber();
+ * $client->getEmitter()->attach($subscriber);
+ * ```
+ */
+class EventSubscriber implements SubscriberInterface
+{
+    const TRACE_CONTEXT_HEADER = 'X-Cloud-Trace-Context';
+
+    /**
+     * Returns an array of event names this subscriber wants to listen to.
+     *
+     * @return array
+     */
+    public function getEvents()
+    {
+        return [
+            'before'    => ['onBefore'],
+            'end'       => ['onEnd']
+        ];
+    }
+
+    /**
+     * Handler for the BeforeEvent request lifecycle event. Adds the current trace context
+     * as the trace context header. Also starts a span representing this outgoing http request.
+     *
+     * @param BeforeEvent $event Event object emitted before a request is sent
+     */
+    public function onBefore(BeforeEvent $event)
+    {
+        $request = $event->getRequest();
+        if ($context = RequestTracer::context()) {
+            $request->setHeader(self::TRACE_CONTEXT_HEADER, $context);
+        }
+        RequestTracer::startSpan([
+            'name' => 'GuzzleHttp::request',
+            'labels' => [
+                'method' => $request->getMethod(),
+                'uri' => $request->getUrl()
+            ]
+        ]);
+    }
+
+    /**
+     * Handler for the EndEvent request lifecycle event. Ends the current span which should be
+     * the span started in the BeforeEvent handler.
+     *
+     * @param EndEvent $event A terminal event that is emitted when a request transaction has ended
+     */
+    public function onEnd(EndEvent $event)
+    {
+        RequestTracer::endSpan();
+    }
+}

--- a/src/Trace/Integrations/Guzzle/Middleware.php
+++ b/src/Trace/Integrations/Guzzle/Middleware.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations\Guzzle;
+
+use OpenCensus\Trace\RequestTracer;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * This class handles integration with GuzzleHttp 6. Adding this middleware to
+ * your Guzzle client, will enable distrubted tracing by passing along the trace context
+ * header and will also create trace spans for all outgoing requests.
+ *
+ * Example:
+ * ```
+ * use GuzzleHttp\Client;
+ * use GuzzleHttp\HandlerStack;
+ * use OpenCensus\Trace\Integrations\Guzzle\Middleware;
+ *
+ * $stack = new HandlerStack();
+ * $stack->setHandler(\GuzzleHttp\choose_handler());
+ * $stack->push(new Middleware());
+ * $client = new Client(['handler' => $stack]);
+ * ```
+ */
+class Middleware
+{
+    const TRACE_CONTEXT_HEADER = 'X-Cloud-Trace-Context';
+
+    /**
+     * Magic method which makes this object callable. Guzzle middleware are expected to be
+     * callables.
+     *
+     * @param  callable $handler The next handler in the HandlerStack
+     * @return callable
+     */
+    public function __invoke(callable $handler)
+    {
+        return function (RequestInterface $request, $options) use ($handler) {
+            if ($context = RequestTracer::context()) {
+                $request = $request->withHeader(self::TRACE_CONTEXT_HEADER, $context);
+            }
+            return RequestTracer::inSpan([
+                'name' => 'GuzzleHttp::request',
+                'labels' => [
+                    'method' => $request->getMethod(),
+                    'uri' => (string)$request->getUri()
+                ]
+            ], $handler, [$request, $options]);
+        };
+    }
+}

--- a/src/Trace/Integrations/IntegrationInterface.php
+++ b/src/Trace/Integrations/IntegrationInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+/**
+ * Common interface for enabling Trace integration for various frameworks and libraries.
+ */
+interface IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to a framework or library
+     */
+    public static function load();
+}

--- a/src/Trace/Integrations/Laravel.php
+++ b/src/Trace/Integrations/Laravel.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+use Illuminate\View\Engines\CompilerEngine;
+
+/**
+ * This class handles instrumenting the Laravel framework's standard stack using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Laravel
+ *
+ * Laravel::load();
+ */
+class Laravel implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to the Laravel framework
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        Eloquent::load();
+
+        // Create a trace span for every template rendered
+        // public function get($path, array $data = array())
+        opencensus_method(CompilerEngine::class, 'get', function ($scope, $path, $data) {
+            return [
+                'name' => 'laravel/view',
+                'labels' => [
+                    'path' => $path
+                ]
+            ];
+        });
+    }
+}

--- a/src/Trace/Integrations/Laravel.php
+++ b/src/Trace/Integrations/Laravel.php
@@ -36,6 +36,7 @@ class Laravel implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load Laravel integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Laravel.php
+++ b/src/Trace/Integrations/Laravel.php
@@ -43,7 +43,7 @@ class Laravel implements IntegrationInterface
 
         // Create a trace span for every template rendered
         // public function get($path, array $data = array())
-        opencensus_method(CompilerEngine::class, 'get', function ($scope, $path, $data) {
+        opencensus_trace_method(CompilerEngine::class, 'get', function ($scope, $path, $data) {
             return [
                 'name' => 'laravel/view',
                 'labels' => [

--- a/src/Trace/Integrations/Memcache.php
+++ b/src/Trace/Integrations/Memcache.php
@@ -45,31 +45,31 @@ class Memcache implements IntegrationInterface
         };
 
         // bool Memcache::add ( string $key , mixed $var [, int $flag [, int $expire ]] )
-        opencensus_method('Memcache', 'add', $labelKeys);
+        opencensus_trace_method('Memcache', 'add', $labelKeys);
 
         // string Memcache::get ( string $key [, int &$flags ] )
         // array Memcache::get ( array $keys [, array &$flags ] )
-        opencensus_method('Memcache', 'get', $labelKeys);
+        opencensus_trace_method('Memcache', 'get', $labelKeys);
 
         // bool Memcache::set ( string $key , mixed $var [, int $flag [, int $expire ]] )
-        opencensus_method('Memcache', 'set', $labelKeys);
+        opencensus_trace_method('Memcache', 'set', $labelKeys);
 
         // bool Memcache::delete ( string $key [, int $timeout = 0 ] )
-        opencensus_method('Memcache', 'delete', $labelKeys);
+        opencensus_trace_method('Memcache', 'delete', $labelKeys);
 
-        opencensus_method('Memcache', 'flush');
+        opencensus_trace_method('Memcache', 'flush');
 
         // bool Memcache::replace ( string $key , mixed $var [, int $flag [, int $expire ]] )
-        opencensus_method('Memcache', 'replace', $labelKeys);
+        opencensus_trace_method('Memcache', 'replace', $labelKeys);
 
         // int Memcache::increment ( string $key [, int $value = 1 ] )
-        opencensus_method('Memcache', 'increment', $labelKeys);
+        opencensus_trace_method('Memcache', 'increment', $labelKeys);
 
         // int Memcache::decrement ( string $key [, int $value = 1 ] )
-        opencensus_method('Memcache', 'decrement', $labelKeys);
+        opencensus_trace_method('Memcache', 'decrement', $labelKeys);
 
         // bool Memcache::connect ( string $host [, int $port [, int $timeout ]] )
-        opencensus_method('Memcache', 'connect', function ($host) {
+        opencensus_trace_method('Memcache', 'connect', function ($host) {
             return [
                 'labels' => [
                     'host' => $host

--- a/src/Trace/Integrations/Memcache.php
+++ b/src/Trace/Integrations/Memcache.php
@@ -38,44 +38,62 @@ class Memcache implements IntegrationInterface
             return;
         }
 
-        $labelKeys = function ($memcache, $keyOrKeys) {
-            $key = is_array($keyOrKeys) ? implode(",", $keyOrKeys) : $keyOrKeys;
-            return [
-                'labels' => ['key' => $key]
-            ];
-        };
-
         // bool Memcache::add ( string $key , mixed $var [, int $flag [, int $expire ]] )
-        opencensus_trace_method('Memcache', 'add', $labelKeys);
+        opencensus_trace_method('Memcache', 'add', [self::class, 'handleLabels']);
 
         // string Memcache::get ( string $key [, int &$flags ] )
         // array Memcache::get ( array $keys [, array &$flags ] )
-        opencensus_trace_method('Memcache', 'get', $labelKeys);
+        opencensus_trace_method('Memcache', 'get', [self::class, 'handleLabels']);
 
         // bool Memcache::set ( string $key , mixed $var [, int $flag [, int $expire ]] )
-        opencensus_trace_method('Memcache', 'set', $labelKeys);
+        opencensus_trace_method('Memcache', 'set', [self::class, 'handleLabels']);
 
         // bool Memcache::delete ( string $key [, int $timeout = 0 ] )
-        opencensus_trace_method('Memcache', 'delete', $labelKeys);
+        opencensus_trace_method('Memcache', 'delete', [self::class, 'handleLabels']);
 
         opencensus_trace_method('Memcache', 'flush');
 
         // bool Memcache::replace ( string $key , mixed $var [, int $flag [, int $expire ]] )
-        opencensus_trace_method('Memcache', 'replace', $labelKeys);
+        opencensus_trace_method('Memcache', 'replace', [self::class, 'handleLabels']);
 
         // int Memcache::increment ( string $key [, int $value = 1 ] )
-        opencensus_trace_method('Memcache', 'increment', $labelKeys);
+        opencensus_trace_method('Memcache', 'increment', [self::class, 'handleLabels']);
 
         // int Memcache::decrement ( string $key [, int $value = 1 ] )
-        opencensus_trace_method('Memcache', 'decrement', $labelKeys);
+        opencensus_trace_method('Memcache', 'decrement', [self::class, 'handleLabels']);
 
         // bool Memcache::connect ( string $host [, int $port [, int $timeout ]] )
-        opencensus_trace_method('Memcache', 'connect', function ($host) {
-            return [
-                'labels' => [
-                    'host' => $host
-                ]
-            ];
-        });
+        opencensus_trace_method('Memcache', 'connect', [self::class, 'handleConnect']);
+    }
+
+    /**
+     * Handle converting the key or keys provided to a Memcache function into a comma-separated label
+     *
+     * @param \Memcache $memcache
+     * @param array|string $keyOrKeys The key or keys to operate on
+     * @return array
+     */
+    public static function handleLabels($memcache, $keyOrKeys)
+    {
+        $key = is_array($keyOrKeys) ? implode(",", $keyOrKeys) : $keyOrKeys;
+        return [
+            'labels' => ['key' => $key]
+        ];
+    }
+
+    /**
+     * Extract the host as a label
+     *
+     * @param \Memcache $memcache
+     * @param string $host
+     * @return array
+     */
+    public static function handleConnect($memcache, $host)
+    {
+        return [
+            'labels' => [
+                'host' => $host
+            ]
+        ];
     }
 }

--- a/src/Trace/Integrations/Memcache.php
+++ b/src/Trace/Integrations/Memcache.php
@@ -34,6 +34,7 @@ class Memcache implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load Memcache integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Memcache.php
+++ b/src/Trace/Integrations/Memcache.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+/**
+ * This class handles instrumenting memcache requests using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Memcache
+ *
+ * Memcache::load();
+ */
+class Memcache implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to memcache requests
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        $labelKeys = function ($memcache, $keyOrKeys) {
+            $key = is_array($keyOrKeys) ? implode(",", $keyOrKeys) : $keyOrKeys;
+            return [
+                'labels' => ['key' => $key]
+            ];
+        };
+
+        // bool Memcache::add ( string $key , mixed $var [, int $flag [, int $expire ]] )
+        opencensus_method('Memcache', 'add', $labelKeys);
+
+        // string Memcache::get ( string $key [, int &$flags ] )
+        // array Memcache::get ( array $keys [, array &$flags ] )
+        opencensus_method('Memcache', 'get', $labelKeys);
+
+        // bool Memcache::set ( string $key , mixed $var [, int $flag [, int $expire ]] )
+        opencensus_method('Memcache', 'set', $labelKeys);
+
+        // bool Memcache::delete ( string $key [, int $timeout = 0 ] )
+        opencensus_method('Memcache', 'delete', $labelKeys);
+
+        opencensus_method('Memcache', 'flush');
+
+        // bool Memcache::replace ( string $key , mixed $var [, int $flag [, int $expire ]] )
+        opencensus_method('Memcache', 'replace', $labelKeys);
+
+        // int Memcache::increment ( string $key [, int $value = 1 ] )
+        opencensus_method('Memcache', 'increment', $labelKeys);
+
+        // int Memcache::decrement ( string $key [, int $value = 1 ] )
+        opencensus_method('Memcache', 'decrement', $labelKeys);
+
+        // bool Memcache::connect ( string $host [, int $port [, int $timeout ]] )
+        opencensus_method('Memcache', 'connect', function ($host) {
+            return [
+                'labels' => [
+                    'host' => $host
+                ]
+            ];
+        });
+    }
+}

--- a/src/Trace/Integrations/Memcached.php
+++ b/src/Trace/Integrations/Memcached.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+/**
+ * This class handles instrumenting memcache requests using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Memcached
+ *
+ * Memcached::load();
+ */
+class Memcached implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to memcache requests
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        $handleLabels = function ($memcached, $keyOrKeys) {
+            $key = is_array($keyOrKeys) ? implode(",", $keyOrKeys) : $keyOrKeys;
+            return [
+                'labels' => ['key' => $key]
+            ];
+        };
+
+        $handleLabelsByKey = function ($memcached, $serverKey, $keyOrKeys) {
+            $key = is_array($keyOrKeys) ? implode(",", $keyOrKeys) : $keyOrKeys;
+            return [
+                'labels' => [
+                    'serverKey' => $serverKey,
+                    'key' => $key
+                ]
+            ];
+        }
+
+        // bool Memcached::add ( string $key , mixed $value [, int $expiration ] )
+        opencensus_trace_method('Memcached', 'add', $handleLabels);
+
+        // bool Memcached::addByKey ( string $server_key , string $key , mixed $value [, int $expiration ] )
+        opencensus_trace_method('Memcached', 'add', $handleLabelsByKey);
+
+        // bool Memcached::append ( string $key , string $value )
+        opencensus_trace_method('Memcached', 'append', $handleLabels);
+
+        // bool Memcached::appendByKey ( string $server_key , string $key , string $value )
+        opencensus_trace_method('Memcached', 'appendByKey', $handleLabelsByKey);
+
+        // bool Memcached::cas ( float $cas_token , string $key , mixed $value [, int $expiration ] )
+        opencensus_trace_method('Memcached', 'cas', function ($memcached, $casToken, $key) {
+            return [
+                'labels' => [
+                    'casToken' => $casToken,
+                    'key' => $key
+                ]
+            ];
+        });
+
+        // bool Memcached::casByKey ( float $cas_token , string $server_key , string $key , mixed $value [, int $expiration ] )
+        opencensus_trace_method('Memcached', 'casByKey', function ($memcached, $casToken, $serverKey, $key) {
+            return [
+                'labels' => [
+                    'casToken' => $casToken,
+                    'serverKey' => $serverKey,
+                    'key' => $key
+                ]
+            ];
+        });
+
+        // int Memcached::decrement ( string $key [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
+        opencensus_trace_method('Memcached', 'decrement', $handleLabels);
+
+        // int Memcached::decrementByKey ( string $server_key , string $key [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
+        opencensus_trace_method('Memcached', 'decrementByKey', $handleLabelsByKey);
+
+        // bool Memcached::delete ( string $key [, int $time = 0 ] )
+        opencensus_trace_method('Memcached', 'delete', $handleLabels);
+
+        // bool Memcached::deleteByKey ( string $server_key , string $key [, int $time = 0 ] )
+        opencensus_trace_method('Memcached', 'deleteByKey', $handleLabelsByKey);
+
+        // bool Memcached::flush ([ int $delay = 0 ] )
+        opencensus_trace_method('Memcached', 'flush');
+
+        // mixed Memcached::get ( string $key [, callable $cache_cb [, int &$flags ]] )
+        opencensus_trace_method('Memcached', 'get', $handleLabels);
+
+        // mixed Memcached::getByKey ( string $server_key , string $key [, callable $cache_cb [, int $flags ]] )
+        opencensus_trace_method('Memcached', 'getByKey', $handleLabelsByKey);
+
+        // mixed Memcached::getMulti ( array $keys [, int $flags ] )
+        opencensus_trace_method('Memcached', 'getMulti', $handleLabels);
+
+        // array Memcached::getMultiByKey ( string $server_key , array $keys [, int $flags ] )
+        opencensus_trace_method('Memcached', 'getMultiByKey', $handleLabelsByKey);
+
+        // int Memcached::increment ( string $key [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
+        opencensus_trace_method('Memcached', 'increment', $handleLabels);
+
+        // int Memcached::incrementByKey ( string $server_key , string $key [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
+        opencensus_trace_method('Memcached', 'incrementByKey', $handleLabelsByKey);
+
+        // bool Memcached::prepend ( string $key , string $value )
+        opencensus_trace_method('Memcached', 'prepend', $handleLabels);
+
+        // bool Memcached::prependByKey ( string $server_key , string $key , string $value )
+        opencensus_trace_method('Memcached', 'prependByKey', $handleLabelsByKey);
+
+        // bool Memcached::replace ( string $key , mixed $value [, int $expiration ] )
+        opencensus_trace_method('Memcached', 'replace', $handleLabels);
+
+        // bool Memcached::replaceByKey ( string $server_key , string $key , mixed $value [, int $expiration ] )
+        opencensus_trace_method('Memcached', 'replaceByKey', $handleLabelsByKey);
+
+        // bool Memcached::set ( string $key , mixed $value [, int $expiration ] )
+        opencensus_trace_method('Memcached', 'set', $handleLabels);
+
+        // bool Memcached::setByKey ( string $server_key , string $key , mixed $value [, int $expiration ] )
+        opencensus_trace_method('Memcached', 'setByKey', $handleLabelsByKey);
+
+        // bool Memcached::setMulti ( array $items [, int $expiration ] )
+        opencensus_trace_method('Memcached', 'setMulti', function ($memcached, $items) {
+            return [
+                'labels' => ['key' => implode(',', array_keys($items))]
+            ]
+        });
+
+        // bool Memcached::setMultiByKey ( string $server_key , array $items [, int $expiration ] )
+        opencensus_trace_method('Memcached', 'setMultiByKey', function ($memcached, $serverKey, $items) {
+            return [
+                'labels' => [
+                    'serverKey' => $serverKey,
+                    'key' => implode(',', array_keys($items))
+                ]
+            ]
+        });
+
+
+
+    }
+}

--- a/src/Trace/Integrations/Memcached.php
+++ b/src/Trace/Integrations/Memcached.php
@@ -76,7 +76,8 @@ class Memcached implements IntegrationInterface
             ];
         });
 
-        // bool Memcached::casByKey ( float $cas_token , string $server_key , string $key , mixed $value [, int $expiration ] )
+        // bool Memcached::casByKey ( float $cas_token , string $server_key , string $key , mixed $value
+        //                            [, int $expiration ] )
         opencensus_trace_method('Memcached', 'casByKey', function ($memcached, $casToken, $serverKey, $key) {
             return [
                 'labels' => [
@@ -90,7 +91,8 @@ class Memcached implements IntegrationInterface
         // int Memcached::decrement ( string $key [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
         opencensus_trace_method('Memcached', 'decrement', $handleLabels);
 
-        // int Memcached::decrementByKey ( string $server_key , string $key [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
+        // int Memcached::decrementByKey ( string $server_key , string $key [, int $offset = 1 [, int $initial_value = 0
+        //                                 [, int $expiry = 0 ]]] )
         opencensus_trace_method('Memcached', 'decrementByKey', $handleLabelsByKey);
 
         // bool Memcached::delete ( string $key [, int $time = 0 ] )
@@ -117,7 +119,8 @@ class Memcached implements IntegrationInterface
         // int Memcached::increment ( string $key [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
         opencensus_trace_method('Memcached', 'increment', $handleLabels);
 
-        // int Memcached::incrementByKey ( string $server_key , string $key [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
+        // int Memcached::incrementByKey ( string $server_key , string $key [, int $offset = 1 [, int $initial_value = 0
+        //                                 [, int $expiry = 0 ]]] )
         opencensus_trace_method('Memcached', 'incrementByKey', $handleLabelsByKey);
 
         // bool Memcached::prepend ( string $key , string $value )
@@ -154,8 +157,5 @@ class Memcached implements IntegrationInterface
                 ]
             ]
         });
-
-
-
     }
 }

--- a/src/Trace/Integrations/Memcached.php
+++ b/src/Trace/Integrations/Memcached.php
@@ -38,125 +38,188 @@ class Memcached implements IntegrationInterface
             return;
         }
 
-        $handleLabels = function ($memcached, $keyOrKeys) {
-            $key = is_array($keyOrKeys) ? implode(",", $keyOrKeys) : $keyOrKeys;
-            return [
-                'labels' => ['key' => $key]
-            ];
-        };
-
-        $handleLabelsByKey = function ($memcached, $serverKey, $keyOrKeys) {
-            $key = is_array($keyOrKeys) ? implode(",", $keyOrKeys) : $keyOrKeys;
-            return [
-                'labels' => [
-                    'serverKey' => $serverKey,
-                    'key' => $key
-                ]
-            ];
-        }
-
         // bool Memcached::add ( string $key , mixed $value [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'add', $handleLabels);
+        opencensus_trace_method('Memcached', 'add', [self::class, 'handleLabels']);
 
         // bool Memcached::addByKey ( string $server_key , string $key , mixed $value [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'add', $handleLabelsByKey);
+        opencensus_trace_method('Memcached', 'add', [self::class, 'handleLabelsByKey']);
 
         // bool Memcached::append ( string $key , string $value )
-        opencensus_trace_method('Memcached', 'append', $handleLabels);
+        opencensus_trace_method('Memcached', 'append', [self::class, 'handleLabels']);
 
         // bool Memcached::appendByKey ( string $server_key , string $key , string $value )
-        opencensus_trace_method('Memcached', 'appendByKey', $handleLabelsByKey);
+        opencensus_trace_method('Memcached', 'appendByKey', [self::class, 'handleLabelsByKey']);
 
         // bool Memcached::cas ( float $cas_token , string $key , mixed $value [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'cas', function ($memcached, $casToken, $key) {
-            return [
-                'labels' => [
-                    'casToken' => $casToken,
-                    'key' => $key
-                ]
-            ];
-        });
+        opencensus_trace_method('Memcached', 'cas', [self::class, 'handleCas']);
 
         // bool Memcached::casByKey ( float $cas_token , string $server_key , string $key , mixed $value
         //                            [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'casByKey', function ($memcached, $casToken, $serverKey, $key) {
-            return [
-                'labels' => [
-                    'casToken' => $casToken,
-                    'serverKey' => $serverKey,
-                    'key' => $key
-                ]
-            ];
-        });
+        opencensus_trace_method('Memcached', 'casByKey', [self::class, 'handleCasByKey']);
 
         // int Memcached::decrement ( string $key [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
-        opencensus_trace_method('Memcached', 'decrement', $handleLabels);
+        opencensus_trace_method('Memcached', 'decrement', [self::class, 'handleLabels']);
 
         // int Memcached::decrementByKey ( string $server_key , string $key [, int $offset = 1 [, int $initial_value = 0
         //                                 [, int $expiry = 0 ]]] )
-        opencensus_trace_method('Memcached', 'decrementByKey', $handleLabelsByKey);
+        opencensus_trace_method('Memcached', 'decrementByKey', [self::class, 'handleLabelsByKey']);
 
         // bool Memcached::delete ( string $key [, int $time = 0 ] )
-        opencensus_trace_method('Memcached', 'delete', $handleLabels);
+        opencensus_trace_method('Memcached', 'delete', [self::class, 'handleLabels']);
 
         // bool Memcached::deleteByKey ( string $server_key , string $key [, int $time = 0 ] )
-        opencensus_trace_method('Memcached', 'deleteByKey', $handleLabelsByKey);
+        opencensus_trace_method('Memcached', 'deleteByKey', [self::class, 'handleLabelsByKey']);
 
         // bool Memcached::flush ([ int $delay = 0 ] )
         opencensus_trace_method('Memcached', 'flush');
 
         // mixed Memcached::get ( string $key [, callable $cache_cb [, int &$flags ]] )
-        opencensus_trace_method('Memcached', 'get', $handleLabels);
+        opencensus_trace_method('Memcached', 'get', [self::class, 'handleLabels']);
 
         // mixed Memcached::getByKey ( string $server_key , string $key [, callable $cache_cb [, int $flags ]] )
-        opencensus_trace_method('Memcached', 'getByKey', $handleLabelsByKey);
+        opencensus_trace_method('Memcached', 'getByKey', [self::class, 'handleLabelsByKey']);
 
         // mixed Memcached::getMulti ( array $keys [, int $flags ] )
-        opencensus_trace_method('Memcached', 'getMulti', $handleLabels);
+        opencensus_trace_method('Memcached', 'getMulti', [self::class, 'handleLabels']);
 
         // array Memcached::getMultiByKey ( string $server_key , array $keys [, int $flags ] )
-        opencensus_trace_method('Memcached', 'getMultiByKey', $handleLabelsByKey);
+        opencensus_trace_method('Memcached', 'getMultiByKey', [self::class, 'handleLabelsByKey']);
 
         // int Memcached::increment ( string $key [, int $offset = 1 [, int $initial_value = 0 [, int $expiry = 0 ]]] )
-        opencensus_trace_method('Memcached', 'increment', $handleLabels);
+        opencensus_trace_method('Memcached', 'increment', [self::class, 'handleLabels']);
 
         // int Memcached::incrementByKey ( string $server_key , string $key [, int $offset = 1 [, int $initial_value = 0
         //                                 [, int $expiry = 0 ]]] )
-        opencensus_trace_method('Memcached', 'incrementByKey', $handleLabelsByKey);
+        opencensus_trace_method('Memcached', 'incrementByKey', [self::class, 'handleLabelsByKey']);
 
         // bool Memcached::prepend ( string $key , string $value )
-        opencensus_trace_method('Memcached', 'prepend', $handleLabels);
+        opencensus_trace_method('Memcached', 'prepend', [self::class, 'handleLabels']);
 
         // bool Memcached::prependByKey ( string $server_key , string $key , string $value )
-        opencensus_trace_method('Memcached', 'prependByKey', $handleLabelsByKey);
+        opencensus_trace_method('Memcached', 'prependByKey', [self::class, 'handleLabelsByKey']);
 
         // bool Memcached::replace ( string $key , mixed $value [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'replace', $handleLabels);
+        opencensus_trace_method('Memcached', 'replace', [self::class, 'handleLabels']);
 
         // bool Memcached::replaceByKey ( string $server_key , string $key , mixed $value [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'replaceByKey', $handleLabelsByKey);
+        opencensus_trace_method('Memcached', 'replaceByKey', [self::class, 'handleLabelsByKey']);
 
         // bool Memcached::set ( string $key , mixed $value [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'set', $handleLabels);
+        opencensus_trace_method('Memcached', 'set', [self::class, 'handleLabels']);
 
         // bool Memcached::setByKey ( string $server_key , string $key , mixed $value [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'setByKey', $handleLabelsByKey);
+        opencensus_trace_method('Memcached', 'setByKey', [self::class, 'handleLabelsByKey']);
 
         // bool Memcached::setMulti ( array $items [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'setMulti', function ($memcached, $items) {
-            return [
-                'labels' => ['key' => implode(',', array_keys($items))]
-            ]
-        });
+        opencensus_trace_method('Memcached', 'setMulti', [self::class, 'handleSetMulti']);
 
         // bool Memcached::setMultiByKey ( string $server_key , array $items [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'setMultiByKey', function ($memcached, $serverKey, $items) {
-            return [
-                'labels' => [
-                    'serverKey' => $serverKey,
-                    'key' => implode(',', array_keys($items))
-                ]
+        opencensus_trace_method('Memcached', 'setMultiByKey', [self::class, 'handleSetMultiByKey']);
+    }
+
+    /**
+     * Handle converting the key or keys provided to a Memcache function into a comma-separated label
+     *
+     * @param \Memcached $memcached
+     * @param array|string $keyOrKeys The key or keys to operate on
+     * @return array
+     */
+    public static function handleLabels($memcached, $keyOrKeys)
+    {
+        $key = is_array($keyOrKeys) ? implode(",", $keyOrKeys) : $keyOrKeys;
+        return [
+            'labels' => ['key' => $key]
+        ];
+    }
+
+    /**
+     * Handle converting the key or keys provided to a Memcache function into a comma-separated label
+     *
+     * @param \Memcached $memcached
+     * @param string $serverKey The key identifying the server to store the value on or retrieve it from.
+     * @param array|string $keyOrKeys The key or keys to operate on
+     * @return array
+     */
+    public static function handleLabelsByKey($memcached, $serverKey, $keyOrKeys)
+    {
+        $key = is_array($keyOrKeys) ? implode(",", $keyOrKeys) : $keyOrKeys;
+        return [
+            'labels' => [
+                'serverKey' => $serverKey,
+                'key' => $key
             ]
-        });
+        ];
+    }
+
+    /**
+     * Handle converting the key and check and set token to labels
+     *
+     * @param \Memcached $memcached
+     * @param string $casToken The check and set token. Unique value associated with the existing item. Generated by
+     *        memcache.
+     * @param string $key The key or keys to operate on
+     * @return array
+     */
+    public static function handleCas($memcached, $casToken, $key)
+    {
+        return [
+            'labels' => [
+                'casToken' => $casToken,
+                'key' => $key
+            ]
+        ];
+    }
+
+    /**
+     * Handle converting the key and check and set token to labels
+     *
+     * @param \Memcached $memcached
+     * @param string $casToken The check and set token. Unique value associated with the existing item. Generated by
+     *        memcache.
+     * @param string $serverKey The key identifying the server to store the value on or retrieve it from.
+     * @param string $key The key or keys to operate on
+     * @return array
+     */
+    public static function handleCasByKey($memcached, $casToken, $serverKey, $key)
+    {
+        return [
+            'labels' => [
+                'casToken' => $casToken,
+                'serverKey' => $serverKey,
+                'key' => $key
+            ]
+        ];
+    }
+
+    /**
+     * Extract key label from a setMulti command
+     *
+     * @param \Memcached $memcached
+     * @param array $items The items being set in memcached.
+     * @return array
+     */
+    public static function handleSetMulti($memcached, $items)
+    {
+        return [
+            'labels' => ['key' => implode(',', array_keys($items))]
+        ];
+    }
+
+    /**
+     * Extract key label from a setMulti command
+     *
+     * @param \Memcached $memcached
+     * @param string $serverKey The key identifying the server to store the value on or retrieve it from.
+     * @param array $items The items being set in memcached.
+     * @return array
+     */
+    public static function handleSetMultiByKey($memcached, $serverKey, $items)
+    {
+        return [
+            'labels' => [
+                'serverKey' => $serverKey,
+                'key' => implode(',', array_keys($items))
+            ]
+        ];
     }
 }

--- a/src/Trace/Integrations/Memcached.php
+++ b/src/Trace/Integrations/Memcached.php
@@ -34,6 +34,7 @@ class Memcached implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load Memcached integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Mysql.php
+++ b/src/Trace/Integrations/Mysql.php
@@ -34,6 +34,7 @@ class Mysql implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load mysqli integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Mysql.php
+++ b/src/Trace/Integrations/Mysql.php
@@ -38,21 +38,21 @@ class Mysql implements IntegrationInterface
         }
 
         // mixed mysqli_query ( mysqli $link , string $query [, int $resultmode = MYSQLI_STORE_RESULT ] )
-        opencensus_function('mysqli_query', function ($mysqli, $query) {
+        opencensus_trace_function('mysqli_query', function ($mysqli, $query) {
             return [
                 'labels' => ['query' => $query]
             ];
         });
 
         // mysqli_stmt mysqli_prepare ( mysqli $link , string $query )
-        opencensus_function('mysqli_prepare', function ($mysqli, $query) {
+        opencensus_trace_function('mysqli_prepare', function ($mysqli, $query) {
             return [
                 'labels' => ['query' => $query]
             ];
         });
 
         // bool mysqli_commit ( mysqli $link [, int $flags [, string $name ]] )
-        opencensus_function('mysqli_commit', function ($mysqli) {
+        opencensus_trace_function('mysqli_commit', function ($mysqli) {
             if (func_num_args() > 2) {
                 return [
                     'labels' => [
@@ -70,31 +70,31 @@ class Mysql implements IntegrationInterface
         //      [, string $dbname = ""
         //      [, int $port = ini_get("mysqli.default_port")
         //      [, string $socket = ini_get("mysqli.default_socket") ]]]]]] )
-        opencensus_function('mysqli_connect', function ($host) {
+        opencensus_trace_function('mysqli_connect', function ($host) {
             return [
                 'labels' => ['host' => $host]
             ];
         });
 
         // bool mysqli_stmt_execute ( mysqli_stmt $stmt )
-        opencensus_function('mysqli_stmt_execute');
+        opencensus_trace_function('mysqli_stmt_execute');
 
         // mixed mysqli::query ( string $query [, int $resultmode = MYSQLI_STORE_RESULT ] )
-        opencensus_method('mysqli', 'query', function ($mysqli, $query) {
+        opencensus_trace_method('mysqli', 'query', function ($mysqli, $query) {
             return [
                 'labels' => ['query' => $query]
             ];
         });
 
         // mysqli_stmt mysqli::prepare ( string $query )
-        opencensus_method('mysqli', 'prepare', function ($mysqli, $query) {
+        opencensus_trace_method('mysqli', 'prepare', function ($mysqli, $query) {
             return [
                 'labels' => ['query' => $query]
             ];
         });
 
         // bool mysqli::commit ([ int $flags [, string $name ]] )
-        opencensus_method('mysqli', 'commit', function ($mysqli) {
+        opencensus_trace_method('mysqli', 'commit', function ($mysqli) {
             if (func_num_args() > 1) {
                 return [
                     'labels' => [
@@ -112,13 +112,13 @@ class Mysql implements IntegrationInterface
         //      [, string $dbname = ""
         //      [, int $port = ini_get("mysqli.default_port")
         //      [, string $socket = ini_get("mysqli.default_socket") ]]]]]] )
-        opencensus_method('mysqli', '__construct', function ($mysqli, $host) {
+        opencensus_trace_method('mysqli', '__construct', function ($mysqli, $host) {
             return [
                 'labels' => ['host' => $host]
             ];
         });
 
         // bool mysqli_stmt::execute ( void )
-        opencensus_method('mysqli_stmt', 'execute');
+        opencensus_trace_method('mysqli_stmt', 'execute');
     }
 }

--- a/src/Trace/Integrations/Mysql.php
+++ b/src/Trace/Integrations/Mysql.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+/**
+ * This class handles instrumenting mysql requests using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Mysql
+ *
+ * Mysql::load();
+ */
+class Mysql implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to mysql requests
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        // mixed mysqli_query ( mysqli $link , string $query [, int $resultmode = MYSQLI_STORE_RESULT ] )
+        opencensus_function('mysqli_query', function ($mysqli, $query) {
+            return [
+                'labels' => ['query' => $query]
+            ];
+        });
+
+        // mysqli_stmt mysqli_prepare ( mysqli $link , string $query )
+        opencensus_function('mysqli_prepare', function ($mysqli, $query) {
+            return [
+                'labels' => ['query' => $query]
+            ];
+        });
+
+        // bool mysqli_commit ( mysqli $link [, int $flags [, string $name ]] )
+        opencensus_function('mysqli_commit', function ($mysqli) {
+            if (func_num_args() > 2) {
+                return [
+                    'labels' => [
+                        'name' => func_get_arg(3)
+                    ]
+                ];
+            } else {
+                return [];
+            }
+        });
+
+        // mysqli mysqli_connect ([ string $host = ini_get("mysqli.default_host")
+        //      [, string $username = ini_get("mysqli.default_user")
+        //      [, string $passwd = ini_get("mysqli.default_pw")
+        //      [, string $dbname = ""
+        //      [, int $port = ini_get("mysqli.default_port")
+        //      [, string $socket = ini_get("mysqli.default_socket") ]]]]]] )
+        opencensus_function('mysqli_connect', function ($host) {
+            return [
+                'labels' => ['host' => $host]
+            ];
+        });
+
+        // bool mysqli_stmt_execute ( mysqli_stmt $stmt )
+        opencensus_function('mysqli_stmt_execute');
+
+        // mixed mysqli::query ( string $query [, int $resultmode = MYSQLI_STORE_RESULT ] )
+        opencensus_method('mysqli', 'query', function ($mysqli, $query) {
+            return [
+                'labels' => ['query' => $query]
+            ];
+        });
+
+        // mysqli_stmt mysqli::prepare ( string $query )
+        opencensus_method('mysqli', 'prepare', function ($mysqli, $query) {
+            return [
+                'labels' => ['query' => $query]
+            ];
+        });
+
+        // bool mysqli::commit ([ int $flags [, string $name ]] )
+        opencensus_method('mysqli', 'commit', function ($mysqli) {
+            if (func_num_args() > 1) {
+                return [
+                    'labels' => [
+                        'name' => func_get_arg(2)
+                    ]
+                ];
+            } else {
+                return [];
+            }
+        });
+
+        // mysqli::__construct ([ string $host = ini_get("mysqli.default_host")
+        //      [, string $username = ini_get("mysqli.default_user")
+        //      [, string $passwd = ini_get("mysqli.default_pw")
+        //      [, string $dbname = ""
+        //      [, int $port = ini_get("mysqli.default_port")
+        //      [, string $socket = ini_get("mysqli.default_socket") ]]]]]] )
+        opencensus_method('mysqli', '__construct', function ($mysqli, $host) {
+            return [
+                'labels' => ['host' => $host]
+            ];
+        });
+
+        // bool mysqli_stmt::execute ( void )
+        opencensus_method('mysqli_stmt', 'execute');
+    }
+}

--- a/src/Trace/Integrations/PDO.php
+++ b/src/Trace/Integrations/PDO.php
@@ -38,44 +38,63 @@ class PDO implements IntegrationInterface
         }
 
         // public int PDO::exec(string $query)
-        opencensus_trace_method('PDO', 'exec', function ($scope, $query) {
-            return [
-                'labels' => ['query' => $query]
-            ];
-        });
+        opencensus_trace_method('PDO', 'exec', [static::class, 'handleQuery']);
 
         // public PDOStatement PDO::query(string $query)
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_COLUMN, int $colno)
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_CLASS, string $classname, array $ctorargs)
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_INFO, object $object)
-        opencensus_trace_method('PDO', 'query', function ($scope, $query) {
-            return [
-                'labels' => ['query' => $query]
-            ];
-        });
+        opencensus_trace_method('PDO', 'query', [static::class, 'handleQuery']);
 
         // public bool PDO::commit ( void )
         opencensus_trace_method('PDO', 'commit');
 
         // public PDO::__construct(string $dsn [, string $username [, string $password [, array $options]]])
-        opencensus_trace_method('PDO', '__construct', function ($scope, $dsn) {
-            return [
-                'labels' => ['dsn' => $dsn]
-            ];
-        });
+        opencensus_trace_method('PDO', '__construct', [static::class, 'handleConnect']);
 
         // public bool PDOStatement::execute([array $params])
-        opencensus_trace_method('PDOStatement', 'execute', function ($scope) {
-            return [
-                'labels' => ['query' => $scope->queryString]
-            ];
-        });
+        opencensus_trace_method('PDOStatement', 'execute', [static::class, 'handleStatementExecute']);
+
     }
 
-    public static function handleQuery($scope, $query)
+    /**
+     * Handle extracting the SQL query from the first argument
+     *
+     * @param PDO $pdo The connectoin
+     * @param string $query The SQL query to extract
+     * @return array
+     */
+    public static function handleQuery($pdo, $query)
     {
         return [
             'labels' => ['query' => $query]
+        ];
+    }
+
+    /**
+     * Handle extracting the Data Source Name (DSN) from the constructor aruments to PDO
+     *
+     * @param PDO $pdo
+     * @param string $dsn The connection DSN
+     * @return array
+     */
+    public static function handleConnect($pdo, $dsn)
+    {
+        return [
+            'labels' => ['dsn' => $dsn]
+        ];
+    }
+
+    /**
+     * Handle extracting the SQL query from a PDOStatement instance
+     *
+     * @param PDOStatement $statement The prepared statement
+     * @return array
+     */
+    public static function handleStatementExecute($statement)
+    {
+        return [
+            'labels' => ['query' => $statement->queryString]
         ];
     }
 }

--- a/src/Trace/Integrations/PDO.php
+++ b/src/Trace/Integrations/PDO.php
@@ -34,6 +34,7 @@ class PDO implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load PDO integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/PDO.php
+++ b/src/Trace/Integrations/PDO.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+/**
+ * This class handles instrumenting PDO requests using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\PDO
+ *
+ * PDO::load();
+ */
+class PDO implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to the PDO requests
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        // public int PDO::exec(string $query)
+        opencensus_method('PDO', 'exec', function ($scope, $query) {
+            return [
+                'labels' => ['query' => $query]
+            ];
+        });
+
+        // public PDOStatement PDO::query(string $query)
+        // public PDOStatement PDO::query(string $query, int PDO::FETCH_COLUMN, int $colno)
+        // public PDOStatement PDO::query(string $query, int PDO::FETCH_CLASS, string $classname, array $ctorargs)
+        // public PDOStatement PDO::query(string $query, int PDO::FETCH_INFO, object $object)
+        opencensus_method('PDO', 'query', function ($scope, $query) {
+            return [
+                'labels' => ['query' => $query]
+            ];
+        });
+
+        // public bool PDO::commit ( void )
+        opencensus_method('PDO', 'commit');
+
+        // public PDO::__construct(string $dsn [, string $username [, string $password [, array $options]]])
+        opencensus_method('PDO', '__construct', function ($scope, $dsn) {
+            return [
+                'labels' => ['dsn' => $dsn]
+            ];
+        });
+
+        // public bool PDOStatement::execute([array $params])
+        opencensus_method('PDOStatement', 'execute', function ($scope) {
+            return [
+                'labels' => ['query' => $scope->queryString]
+            ];
+        });
+    }
+}

--- a/src/Trace/Integrations/PDO.php
+++ b/src/Trace/Integrations/PDO.php
@@ -38,7 +38,7 @@ class PDO implements IntegrationInterface
         }
 
         // public int PDO::exec(string $query)
-        opencensus_method('PDO', 'exec', function ($scope, $query) {
+        opencensus_trace_method('PDO', 'exec', function ($scope, $query) {
             return [
                 'labels' => ['query' => $query]
             ];
@@ -48,24 +48,24 @@ class PDO implements IntegrationInterface
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_COLUMN, int $colno)
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_CLASS, string $classname, array $ctorargs)
         // public PDOStatement PDO::query(string $query, int PDO::FETCH_INFO, object $object)
-        opencensus_method('PDO', 'query', function ($scope, $query) {
+        opencensus_trace_method('PDO', 'query', function ($scope, $query) {
             return [
                 'labels' => ['query' => $query]
             ];
         });
 
         // public bool PDO::commit ( void )
-        opencensus_method('PDO', 'commit');
+        opencensus_trace_method('PDO', 'commit');
 
         // public PDO::__construct(string $dsn [, string $username [, string $password [, array $options]]])
-        opencensus_method('PDO', '__construct', function ($scope, $dsn) {
+        opencensus_trace_method('PDO', '__construct', function ($scope, $dsn) {
             return [
                 'labels' => ['dsn' => $dsn]
             ];
         });
 
         // public bool PDOStatement::execute([array $params])
-        opencensus_method('PDOStatement', 'execute', function ($scope) {
+        opencensus_trace_method('PDOStatement', 'execute', function ($scope) {
             return [
                 'labels' => ['query' => $scope->queryString]
             ];

--- a/src/Trace/Integrations/PDO.php
+++ b/src/Trace/Integrations/PDO.php
@@ -54,7 +54,6 @@ class PDO implements IntegrationInterface
 
         // public bool PDOStatement::execute([array $params])
         opencensus_trace_method('PDOStatement', 'execute', [static::class, 'handleStatementExecute']);
-
     }
 
     /**

--- a/src/Trace/Integrations/PDO.php
+++ b/src/Trace/Integrations/PDO.php
@@ -71,4 +71,11 @@ class PDO implements IntegrationInterface
             ];
         });
     }
+
+    public static function handleQuery($scope, $query)
+    {
+        return [
+            'labels' => ['query' => $query]
+        ];
+    }
 }

--- a/src/Trace/Integrations/Postgres.php
+++ b/src/Trace/Integrations/Postgres.php
@@ -38,7 +38,7 @@ class Postgres implements IntegrationInterface
         }
 
         // resource pg_query([resource $connection], string $query)
-        opencensus_function('pg_query', function () {
+        opencensus_trace_function('pg_query', function () {
             $query = func_num_args() > 1
                 ? func_get_arg(2)
                 : func_get_arg(1);
@@ -48,7 +48,7 @@ class Postgres implements IntegrationInterface
         });
 
         // resource pg_query_params([resource $connection], $string $query, array $params)
-        opencensus_function('pg_query_params', function () {
+        opencensus_trace_function('pg_query_params', function () {
             $query = func_num_args() > 2
                 ? func_get_arg(2)
                 : func_get_arg(1);
@@ -58,7 +58,7 @@ class Postgres implements IntegrationInterface
         });
 
         // resource pg_execute([resource $connection], string $stmtname, array $params)
-        opencensus_function('pg_execute', function () {
+        opencensus_trace_function('pg_execute', function () {
             $statementName = func_num_args() > 2
                 ? func_get_arg(2)
                 : func_get_arg(1);

--- a/src/Trace/Integrations/Postgres.php
+++ b/src/Trace/Integrations/Postgres.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+/**
+ * This class handles instrumenting postgres requests using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Postgres
+ *
+ * Postgres::load();
+ */
+class Postgres implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to the postgres requests
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        // resource pg_query([resource $connection], string $query)
+        opencensus_function('pg_query', function () {
+            $query = func_num_args() > 1
+                ? func_get_arg(2)
+                : func_get_arg(1);
+            return [
+                'labels' => ['query' => $query]
+            ];
+        });
+
+        // resource pg_query_params([resource $connection], $string $query, array $params)
+        opencensus_function('pg_query_params', function () {
+            $query = func_num_args() > 2
+                ? func_get_arg(2)
+                : func_get_arg(1);
+            return [
+                'labels' => ['query' => $query]
+            ];
+        });
+
+        // resource pg_execute([resource $connection], string $stmtname, array $params)
+        opencensus_function('pg_execute', function () {
+            $statementName = func_num_args() > 2
+                ? func_get_arg(2)
+                : func_get_arg(1);
+            return [
+                'labels' => ['statement' => $statementName]
+            ];
+        });
+    }
+}

--- a/src/Trace/Integrations/Postgres.php
+++ b/src/Trace/Integrations/Postgres.php
@@ -34,6 +34,7 @@ class Postgres implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load pg integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Symfony.php
+++ b/src/Trace/Integrations/Symfony.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * This class handles instrumenting the Symfony framework's standard stack using the opencensus extension.
+ *
+ * Example:
+ * ```
+ * use OpenCensus\Trace\Integrations\Symfony
+ *
+ * Symfony::load();
+ */
+class Symfony implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to the Symfony framework
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        Doctrine::load();
+
+        // public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+        opencensus_method(HttpKernel::class, 'handle', function ($kernel, $request) {
+            return [
+                'name' => 'kernel/handle'
+            ];
+        });
+
+        // public function dispatch($eventName, Event $event = null)
+        opencensus_method(EventDispatcher::class, 'dispatch', function ($dispatcher, $eventName) {
+            return [
+                'name' => $eventName,
+                'labels' => ['eventName' => $eventName]
+            ];
+        });
+    }
+}

--- a/src/Trace/Integrations/Symfony.php
+++ b/src/Trace/Integrations/Symfony.php
@@ -43,14 +43,14 @@ class Symfony implements IntegrationInterface
         Doctrine::load();
 
         // public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
-        opencensus_method(HttpKernel::class, 'handle', function ($kernel, $request) {
+        opencensus_trace_method(HttpKernel::class, 'handle', function ($kernel, $request) {
             return [
                 'name' => 'kernel/handle'
             ];
         });
 
         // public function dispatch($eventName, Event $event = null)
-        opencensus_method(EventDispatcher::class, 'dispatch', function ($dispatcher, $eventName) {
+        opencensus_trace_method(EventDispatcher::class, 'dispatch', function ($dispatcher, $eventName) {
             return [
                 'name' => $eventName,
                 'labels' => ['eventName' => $eventName]

--- a/src/Trace/Integrations/Symfony.php
+++ b/src/Trace/Integrations/Symfony.php
@@ -37,6 +37,7 @@ class Symfony implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load Symfony integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Wordpress.php
+++ b/src/Trace/Integrations/Wordpress.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Integrations;
+
+/**
+ * This class handles instrumenting the Wordpress framework's standard stack using the opencensus extension.
+ */
+class Wordpress implements IntegrationInterface
+{
+    /**
+     * Static method to add instrumentation to the Wordpress framework
+     */
+    public static function load()
+    {
+        if (!extension_loaded('opencensus')) {
+            return;
+        }
+
+        Mysql::load();
+
+        $nameClosure = function () {
+            if (func_num_args() > 0) {
+                return [
+                    'labels' => ['name' => func_get_arg(1)]
+                ];
+            }
+            return [];
+        };
+
+        // void function get_sidebar( $name = null )
+        opencensus_function('get_sidebar', $nameClosure);
+
+        // void function get_header( $name = null )
+        opencensus_function('get_header', $nameClosure);
+
+        // function get_footer( $name = null )
+        opencensus_function('get_footer', $nameClosure);
+
+        // bool function load_textdomain( $domain, $mofile )
+        opencensus_function('load_textdomain', function ($name, $mofile) {
+            return [
+                'labels' => ['name' => $name]
+            ];
+        });
+
+        // void load_template(string $template, bool $require_once = true)
+        opencensus_function('load_template', function ($template) {
+            return [
+                'labels' => ['template' => $template]
+            ];
+        });
+    }
+}

--- a/src/Trace/Integrations/Wordpress.php
+++ b/src/Trace/Integrations/Wordpress.php
@@ -28,6 +28,7 @@ class Wordpress implements IntegrationInterface
     public static function load()
     {
         if (!extension_loaded('opencensus')) {
+            trigger_error('opencensus extension required to load Wordpress integrations.', E_USER_WARNING);
             return;
         }
 

--- a/src/Trace/Integrations/Wordpress.php
+++ b/src/Trace/Integrations/Wordpress.php
@@ -43,23 +43,23 @@ class Wordpress implements IntegrationInterface
         };
 
         // void function get_sidebar( $name = null )
-        opencensus_function('get_sidebar', $nameClosure);
+        opencensus_trace_function('get_sidebar', $nameClosure);
 
         // void function get_header( $name = null )
-        opencensus_function('get_header', $nameClosure);
+        opencensus_trace_function('get_header', $nameClosure);
 
         // function get_footer( $name = null )
-        opencensus_function('get_footer', $nameClosure);
+        opencensus_trace_function('get_footer', $nameClosure);
 
         // bool function load_textdomain( $domain, $mofile )
-        opencensus_function('load_textdomain', function ($name, $mofile) {
+        opencensus_trace_function('load_textdomain', function ($name, $mofile) {
             return [
                 'labels' => ['name' => $name]
             ];
         });
 
         // void load_template(string $template, bool $require_once = true)
-        opencensus_function('load_template', function ($template) {
+        opencensus_trace_function('load_template', function ($template) {
             return [
                 'labels' => ['template' => $template]
             ];

--- a/tests/unit/Trace/Integrations/CurlTest.php
+++ b/tests/unit/Trace/Integrations/CurlTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Unit\Trace\Integrations;
+
+use OpenCensus\Trace\Integrations\Curl;
+
+/**
+ * @group trace
+ */
+class CurlTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLoadUrlFromResource()
+    {
+        $resource = curl_init('https://www.google.com');
+
+        $spanOptions = Curl::handleCurlResource($resource);
+        $expected = [
+            'labels' => [
+                'uri' => 'https://www.google.com'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+}

--- a/tests/unit/Trace/Integrations/MemcacheTest.php
+++ b/tests/unit/Trace/Integrations/MemcacheTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Unit\Trace\Integrations;
+
+use OpenCensus\Trace\Integrations\Memcache;
+
+/**
+ * @group trace
+ */
+class MemcacheTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHandleLabelString()
+    {
+        $key = 'mykey';
+        $memcache = null;
+
+        $spanOptions = Memcache::handleLabels($memcache, $key);
+        $expected = [
+            'labels' => [
+                'key' => 'mykey'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+
+    public function testHandleLabelArray()
+    {
+        $key = [
+            'key1',
+            'key2'
+        ];
+        $memcache = null;
+
+        $spanOptions = Memcache::handleLabels($memcache, $key);
+        $expected = [
+            'labels' => [
+                'key' => 'key1,key2'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+}

--- a/tests/unit/Trace/Integrations/MemcachedTest.php
+++ b/tests/unit/Trace/Integrations/MemcachedTest.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Unit\Trace\Integrations;
+
+use OpenCensus\Trace\Integrations\Memcached;
+
+/**
+ * @group trace
+ */
+class MemcachedTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHandleLabelsString()
+    {
+        $key = 'mykey';
+        $memcache = null;
+
+        $spanOptions = Memcached::handleLabels($memcache, $key);
+        $expected = [
+            'labels' => [
+                'key' => 'mykey'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+
+    public function testHandleLabelsArray()
+    {
+        $key = [
+            'key1',
+            'key2'
+        ];
+        $memcache = null;
+
+        $spanOptions = Memcached::handleLabels($memcache, $key);
+        $expected = [
+            'labels' => [
+                'key' => 'key1,key2'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+
+    public function testHandleLabelsByKeyString()
+    {
+        $key = 'mykey';
+        $memcache = null;
+        $serverKey = 'server1';
+
+        $spanOptions = Memcached::handleLabelsByKey($memcache, $serverKey, $key);
+        $expected = [
+            'labels' => [
+                'serverKey' => 'server1',
+                'key' => 'mykey'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+
+    public function testHandleLabelsByKeyArray()
+    {
+        $key = [
+            'key1',
+            'key2'
+        ];
+        $memcache = null;
+        $serverKey = 'server1';
+
+        $spanOptions = Memcached::handleLabelsByKey($memcache, $serverKey, $key);
+        $expected = [
+            'labels' => [
+                'serverKey' => 'server1',
+                'key' => 'key1,key2'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+
+    public function testHandleCas()
+    {
+        $memcache = null;
+        $casToken = 'token1';
+        $key = 'key1';
+
+        $spanOptions = Memcached::handleCas($memcache, $casToken, $key);
+        $expected = [
+            'labels' => [
+                'casToken' => 'token1',
+                'key' => 'key1'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+
+    public function testHandleCasByKey()
+    {
+        $memcache = null;
+        $casToken = 'token1';
+        $serverKey = 'server1';
+        $key = 'key1';
+
+        $spanOptions = Memcached::handleCasByKey($memcache, $casToken, $serverKey, $key);
+        $expected = [
+            'labels' => [
+                'casToken' => 'token1',
+                'serverKey' => 'server1',
+                'key' => 'key1'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+
+    public function testHandleSetMulti()
+    {
+        $memcache = null;
+        $items = [
+            'foo' => 'bar',
+            'asdf' => 'qwer'
+        ];
+
+        $spanOptions = Memcached::handleSetMulti($memcache, $items);
+        $expected = [
+            'labels' => [
+                'key' => 'foo,asdf'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+
+    public function testHandleSetMultiByKey()
+    {
+        $memcache = null;
+        $serverKey = 'server1';
+        $items = [
+            'foo' => 'bar',
+            'asdf' => 'qwer'
+        ];
+
+        $spanOptions = Memcached::handleSetMultiByKey($memcache, $serverKey, $items);
+        $expected = [
+            'labels' => [
+                'serverKey' => 'server1',
+                'key' => 'foo,asdf'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+}

--- a/tests/unit/Trace/Integrations/PDOTest.php
+++ b/tests/unit/Trace/Integrations/PDOTest.php
@@ -38,4 +38,22 @@ class PDOTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $spanOptions);
     }
+
+    public function testHandleConnect()
+    {
+        $dsn = 'mysql:host=localhost;dbname=testdb';
+        $spanOptions = PDO::handleConnect(null, $dsn);
+        $expected = [
+            'labels' => [
+                'dsn' => 'mysql:host=localhost;dbname=testdb'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+
+    public function testStatmentExecute()
+    {
+        $this->markTestSkipped('Cannot test without a database instance');
+    }
 }

--- a/tests/unit/Trace/Integrations/PDOTest.php
+++ b/tests/unit/Trace/Integrations/PDOTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Unit\Trace\Integrations;
+
+use OpenCensus\Trace\Integrations\PDO;
+
+/**
+ * @group trace
+ */
+class PDOTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHandleQuery()
+    {
+        $scope = null;
+        $query = 'select * from users';
+
+        $spanOptions = PDO::handleQuery($scope, $query);
+        $expected = [
+            'labels' => [
+                'query' => 'select * from users'
+            ]
+        ];
+
+        $this->assertEquals($expected, $spanOptions);
+    }
+}

--- a/tests/unit/Trace/Propagator/GrpcMetadataPropagatorTest.php
+++ b/tests/unit/Trace/Propagator/GrpcMetadataPropagatorTest.php
@@ -36,7 +36,7 @@ class GrpcMetadataPropagatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseContext($traceId, $spanId, $enabled, $header)
     {
-        $formatter = new HttpHeaderPropagator();
+        $formatter = new GrpcMetadataPropagator();
         $context = $formatter->parse(['grpc-trace-bin' => $header]);
         $this->assertEquals($traceId, $context->traceId());
         $this->assertEquals($spanId, $context->spanId());
@@ -49,7 +49,7 @@ class GrpcMetadataPropagatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testToString($traceId, $spanId, $enabled, $expected)
     {
-        $formatter = new HttpHeaderPropagator();
+        $formatter = new GrpcMetadataPropagator();
         $context = new TraceContext($traceId, $spanId, $enabled);
         $this->assertEquals($expected, $formatter->serialize($context));
     }

--- a/tests/unit/Trace/Tracer/ExtentionTracerTest.php
+++ b/tests/unit/Trace/Tracer/ExtentionTracerTest.php
@@ -30,28 +30,30 @@ class ExtensionTracerTest extends \PHPUnit_Framework_TestCase
         if (!extension_loaded('opencensus')) {
             $this->markTestSkipped('Must have the stackdriver_trace extension installed to run this test.');
         }
+        opencensus_trace_clear();
     }
 
     public function testMaintainsContext()
     {
-        $initialContext = new TraceContext('traceid', 'spanid');
+        $parentSpanId = 12345;
+        $initialContext = new TraceContext('traceid', $parentSpanId);
 
         $tracer = new ExtensionTracer($initialContext);
         $context = $tracer->context();
 
         $this->assertEquals('traceid', $context->traceId());
-        $this->assertEquals('spanid', $context->spanId());
+        $this->assertEquals($parentSpanId, $context->spanId());
 
-        $tracer->inSpan(['name' => 'test'], function() use ($tracer) {
+        $tracer->inSpan(['name' => 'test'], function() use ($tracer, $parentSpanId) {
             $context = $tracer->context();
-            $this->assertNotEquals('spanid', $context->spanId());
+            $this->assertNotEquals($parentSpanId, $context->spanId());
         });
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
         $span = $spans[0];
         $this->assertEquals('test', $span->name());
-        $this->assertEquals('spanid', $span->parentSpanId());
+        $this->assertEquals($parentSpanId, $span->parentSpanId());
     }
 
     public function testAddsLabelsToCurrentSpan()

--- a/tests/unit/Trace/Tracer/ExtentionTracerTest.php
+++ b/tests/unit/Trace/Tracer/ExtentionTracerTest.php
@@ -28,7 +28,7 @@ class ExtensionTracerTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         if (!extension_loaded('opencensus')) {
-            $this->markTestSkipped('Must have the stackdriver_trace extension installed to run this test.');
+            $this->markTestSkipped('Must have the opencensus extension installed to run this test.');
         }
         opencensus_trace_clear();
     }


### PR DESCRIPTION
This PR adds the framework integrations for Laravel, Symfony, and Wordpress using the `opencensus` extension. Also adds support for tracing memcache(d), mysql, PDO, postgres, grpc, and guzzle.