### PR TITLE
Allow user to supply a callback function

### DIFF
--- a/ext/README.md
+++ b/ext/README.md
@@ -96,7 +96,7 @@ opencensus_trace_method('Foobar', '__construct');
 $foobar = new Foobar();
 ```
 
-The `$handler` parameter can be either an array or a closure callback.
+The `$handler` parameter can be either an array or a callable.
 
 If an array is provided, it should be an associative array with the following optional keys:
 
@@ -105,8 +105,8 @@ If an array is provided, it should be an associative array with the following op
 * `endTime` - float - the end time of the span. **Defaults to** the time that the method invocation completed.
 * `labels` - array - an associative array of string => string tags for this span.
 
-If a closure is provided, it will be passed the instance of the class (scope) and a copy of each parameter
-provided to the watched method. The closure should return an array with the above options. If the closure does
+If a callback is provided, it will be passed the instance of the class (scope) and a copy of each parameter
+provided to the watched method. The callback should return an array with the above options. If the callback does
 not return an array, an `E_USER_WARNING` error is thrown.
 
 ```php
@@ -126,6 +126,17 @@ opencensus_trace_method('Foobar', '__construct', function ($scope, $constructArg
         ]
     ];
 });
+
+// Example: supply a callback
+function my_callback($scope, $constructArg1, $constructArg2)
+{
+    return [
+        'labels' => [
+            'arg1' => $constructArg1
+        ]
+    ];
+}
+opencensus_trace_method('Foobar', '__construct', 'my_callback');
 ```
 
 To trace a function, use the `opencensus_trace_function`:
@@ -135,7 +146,7 @@ To trace a function, use the `opencensus_trace_function`:
  * Trace each invocation of the specified function
  *
  * @param  string $functionName
- * @param  array|Closure $handler
+ * @param  array|callback $handler
  * @return bool
  */
 function opencensus_trace_function($functionName, $handler = []);
@@ -145,8 +156,8 @@ opencensus_trace_function('var_dump');
 var_dump(123);
 ```
 
-Just like tracing a method, you can provide a `$handler` option which can be an array or a closure. The behavior
-is the same as the method tracing, except that the closure will not be passed the scope parameter as there is
+Just like tracing a method, you can provide a `$handler` option which can be an array or a callback. The behavior
+is the same as the method tracing, except that the callback will not be passed the scope parameter as there is
 not object scope available.
 
 ```php

--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -577,7 +577,7 @@ void opencensus_trace_execute_internal(INTERNAL_FUNCTION_PARAMETERS)
  * Register the provided function for tracing.
  *
  * @param string $functionName
- * @param array|Closure $handler
+ * @param array|callable $handler
  * @return bool
  */
 PHP_FUNCTION(opencensus_trace_function)
@@ -608,7 +608,7 @@ PHP_FUNCTION(opencensus_trace_function)
  *
  * @param string $className
  * @param string $methodName
- * @param array|Closure $handler
+ * @param array|callable $handler
  * @return bool
  */
 PHP_FUNCTION(opencensus_trace_method)

--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -236,16 +236,61 @@ static int opencensus_trace_zend_fcall_closure(zend_execute_data *execute_data, 
 }
 
 /**
+ * Call the provided callback with the provided parameters to the traced
+ * function. The callback must return an array or an E_WARNING is raised.
+ */
+static int opencensus_trace_call_user_function_callback(zend_execute_data *execute_data, opencensus_trace_span_t *span, zval *callback, zval *callback_result TSRMLS_DC)
+{
+    int i, num_args = EX_NUM_ARGS(), has_scope = 0;
+    zval *args = emalloc((num_args + 1) * sizeof(zval));
+
+    if (getThis() == NULL) {
+        ZVAL_NULL(&args[0]);
+    } else {
+        has_scope = 1;
+        ZVAL_ZVAL(&args[0], getThis(), 0, 1);
+    }
+
+    for (i = 0; i < num_args; i++) {
+        ZVAL_ZVAL(&args[i + has_scope], EX_VAR_NUM(i), 0, 1);
+    }
+
+    if (call_user_function_ex(EG(function_table), NULL, callback, callback_result, num_args + has_scope, args, 0, NULL) != SUCCESS) {
+        efree(args);
+        return FAILURE;
+    }
+    efree(args);
+
+    if (Z_TYPE_P(callback_result) != IS_ARRAY) {
+        /* only raise the warning if the closure succeeded */
+        php_error_docref(NULL, E_WARNING, "Trace callback should return array");
+        return FAILURE;
+    }
+
+    return SUCCESS;
+}
+
+/**
  * Handle the callback for the traced method depending on the type
- * - if the zval is an array, then assume it's the trace span initialization
+ * - if the zval is an associative array, then assume it's the trace span initialization
  *   options
+ * - if the zval is an array that looks like a callable, then assume it's a callable
  * - if the zval is a Closure, then execute the closure and take the results as
  *   the trace span initialization options
  */
 static void opencensus_trace_execute_callback(opencensus_trace_span_t *span, zend_execute_data *execute_data, zval *span_options TSRMLS_DC)
 {
     if (Z_TYPE_P(span_options) == IS_ARRAY) {
-        opencensus_trace_span_apply_span_options(span, span_options);
+        zend_string *callback_name;
+        if (zend_is_callable(span_options, 0, &callback_name)) {
+            zval callback_result;
+            if (opencensus_trace_call_user_function_callback(execute_data, span, span_options, &callback_result TSRMLS_CC) == SUCCESS) {
+                opencensus_trace_span_apply_span_options(span, &callback_result);
+            }
+        } else {
+            opencensus_trace_span_apply_span_options(span, span_options);
+        }
+        zend_string_release(callback_name);
     } else if ( (Z_TYPE_P(span_options) == IS_OBJECT) &&
                 (Z_OBJCE_P(span_options) == zend_ce_closure)) {
         zval closure_result;

--- a/ext/tests/function_callback_array.phpt
+++ b/ext/tests/function_callback_array.phpt
@@ -1,0 +1,49 @@
+--TEST--
+OpenCensus Trace: Customize the trace span options for a function with a callback closure
+--FILE--
+<?php
+
+require_once(__DIR__ . '/common.php');
+
+class CallbackTest
+{
+    public static function handle()
+    {
+        return ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer', 'zxcv' => 'jkl;']];
+    }
+}
+
+// 1: Sanity test a simple profile run
+opencensus_trace_function("bar", ['CallbackTest', 'handle']);
+bar();
+$traces = opencensus_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+
+$test = gettype($span->spanId());
+echo "Span id is a $test\n";
+
+echo "Span name is: '{$span->name()}'\n";
+
+$test = gettype($span->startTime()) == 'double';
+echo "Span startTime is a double: $test\n";
+
+echo "Span startTime is: '{$span->startTime()}'\n";
+
+$test = gettype($span->endTime()) == 'double';
+echo "Span endTime is a double: $test\n";
+
+print_r($span->labels());
+?>
+--EXPECT--
+Number of traces: 1
+Span id is a integer
+Span name is: 'foo'
+Span startTime is a double: 1
+Span startTime is: '0.1'
+Span endTime is a double: 1
+Array
+(
+    [asdf] => qwer
+    [zxcv] => jkl;
+)

--- a/ext/tests/function_callback_callable_wrong_return.phpt
+++ b/ext/tests/function_callback_callable_wrong_return.phpt
@@ -1,0 +1,17 @@
+--TEST--
+OpenCensus Trace: Callback returning a non-array response should yield a warning.
+--FILE--
+<?php
+
+require_once(__DIR__ . '/common.php');
+
+function wrong_return($x)
+{
+    return $x;
+}
+
+opencensus_trace_function('foo', 'wrong_return');
+foo(3);
+?>
+--EXPECTF--
+Warning: main(): Trace callback should return array in %s on line %d

--- a/ext/tests/function_callback_static_string.phpt
+++ b/ext/tests/function_callback_static_string.phpt
@@ -1,20 +1,20 @@
 --TEST--
-OpenCensus Trace: Customize the trace span options for a function with a callback array
+OpenCensus Trace: Customize the trace span options for a function with a callback string with static method
 --FILE--
 <?php
 
 require_once(__DIR__ . '/common.php');
 
-class CallbackTest
+class MyCallback
 {
-    public static function handle()
+    public static function callbackHandle()
     {
         return ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer', 'zxcv' => 'jkl;']];
     }
 }
 
 // 1: Sanity test a simple profile run
-opencensus_trace_function("bar", ['CallbackTest', 'handle']);
+opencensus_trace_function("bar", 'MyCallback::callbackHandle');
 bar();
 $traces = opencensus_trace_list();
 echo "Number of traces: " . count($traces) . "\n";

--- a/ext/tests/function_callback_string.phpt
+++ b/ext/tests/function_callback_string.phpt
@@ -1,20 +1,17 @@
 --TEST--
-OpenCensus Trace: Customize the trace span options for a function with a callback array
+OpenCensus Trace: Customize the trace span options for a function with a callback string
 --FILE--
 <?php
 
 require_once(__DIR__ . '/common.php');
 
-class CallbackTest
+function callbackHandle()
 {
-    public static function handle()
-    {
-        return ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer', 'zxcv' => 'jkl;']];
-    }
+    return ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer', 'zxcv' => 'jkl;']];
 }
 
 // 1: Sanity test a simple profile run
-opencensus_trace_function("bar", ['CallbackTest', 'handle']);
+opencensus_trace_function("bar", 'callbackHandle');
 bar();
 $traces = opencensus_trace_list();
 echo "Number of traces: " . count($traces) . "\n";

--- a/ext/tests/method_callback_array.phpt
+++ b/ext/tests/method_callback_array.phpt
@@ -1,5 +1,5 @@
 --TEST--
-OpenCensus Trace: Customize the trace span options for a function with a callback closure
+OpenCensus Trace: Customize the trace span options for a function with a callback array
 --FILE--
 <?php
 

--- a/ext/tests/method_callback_array.phpt
+++ b/ext/tests/method_callback_array.phpt
@@ -1,0 +1,50 @@
+--TEST--
+OpenCensus Trace: Customize the trace span options for a function with a callback closure
+--FILE--
+<?php
+
+require_once(__DIR__ . '/common.php');
+
+class CallbackTest
+{
+    public static function handle()
+    {
+        return ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer', 'zxcv' => 'jkl;']];
+    }
+}
+
+// 1: Sanity test a simple profile run
+opencensus_trace_method("Foo", "bar", ['CallbackTest', 'handle']);
+$f = new Foo();
+$f->bar();
+$traces = opencensus_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+
+$test = gettype($span->spanId());
+echo "Span id is a $test\n";
+
+echo "Span name is: '{$span->name()}'\n";
+
+$test = gettype($span->startTime()) == 'double';
+echo "Span startTime is a double: $test\n";
+
+echo "Span startTime is: '{$span->startTime()}'\n";
+
+$test = gettype($span->endTime()) == 'double';
+echo "Span endTime is a double: $test\n";
+
+print_r($span->labels());
+?>
+--EXPECT--
+Number of traces: 1
+Span id is a integer
+Span name is: 'foo'
+Span startTime is a double: 1
+Span startTime is: '0.1'
+Span endTime is a double: 1
+Array
+(
+    [asdf] => qwer
+    [zxcv] => jkl;
+)

--- a/ext/tests/method_callback_string.phpt
+++ b/ext/tests/method_callback_string.phpt
@@ -1,21 +1,19 @@
 --TEST--
-OpenCensus Trace: Customize the trace span options for a function with a callback array
+OpenCensus Trace: Customize the trace span options for a function with a callback closure
 --FILE--
 <?php
 
 require_once(__DIR__ . '/common.php');
 
-class CallbackTest
+function callbackHandle()
 {
-    public static function handle()
-    {
-        return ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer', 'zxcv' => 'jkl;']];
-    }
+    return ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer', 'zxcv' => 'jkl;']];
 }
 
 // 1: Sanity test a simple profile run
-opencensus_trace_function("bar", ['CallbackTest', 'handle']);
-bar();
+opencensus_trace_method("Foo", "bar", 'callbackHandle');
+$f = new Foo();
+$f->bar();
 $traces = opencensus_trace_list();
 echo "Number of traces: " . count($traces) . "\n";
 $span = $traces[0];

--- a/ext/tests/method_callback_string.phpt
+++ b/ext/tests/method_callback_string.phpt
@@ -1,5 +1,5 @@
 --TEST--
-OpenCensus Trace: Customize the trace span options for a function with a callback closure
+OpenCensus Trace: Customize the trace span options for a method with a callback string
 --FILE--
 <?php
 

--- a/ext/tests/module_callback_static_string.phpt
+++ b/ext/tests/module_callback_static_string.phpt
@@ -1,21 +1,22 @@
 --TEST--
-OpenCensus Trace: Customize the trace span options for a function with a callback array
+OpenCensus Trace: Customize the trace span options for a function with a callback string with static method
 --FILE--
 <?php
 
 require_once(__DIR__ . '/common.php');
 
-class CallbackTest
+class MyCallback
 {
-    public static function handle()
+    public static function callbackHandle()
     {
         return ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer', 'zxcv' => 'jkl;']];
     }
 }
 
 // 1: Sanity test a simple profile run
-opencensus_trace_function("bar", ['CallbackTest', 'handle']);
-bar();
+opencensus_trace_method("Foo", "bar", 'MyCallback::callbackHandle');
+$f = new Foo();
+$f->bar();
 $traces = opencensus_trace_list();
 echo "Number of traces: " . count($traces) . "\n";
 $span = $traces[0];


### PR DESCRIPTION
Enables:
* `opencensus_trace_function('function_name', ['MyClass', 'myMethod'])`
* `opencensus_trace_function('function_name', 'MyClass::myMethod'])`
* `opencensus_trace_method('SomeClass', 'method_name', ['MyClass', 'myMethod'])`
* `opencensus_trace_method('SomeClass', 'method_name', 'MyClass::myMethod'])`