### PR TITLE
Span kind

### DIFF
--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -246,6 +246,7 @@ static opencensus_trace_span_t *opencensus_trace_begin(zend_string *function_nam
 
     span->start = opencensus_now();
     span->name = zend_string_copy(function_name);
+    span->kind = OPENCENSUS_TRACE_SPAN_KIND_UNKNOWN;
 
 #if PHP_VERSION_ID < 70100
     if (!BG(mt_rand_is_seeded)) {
@@ -604,6 +605,7 @@ PHP_FUNCTION(opencensus_trace_list)
         zend_update_property_str(opencensus_trace_span_ce, &span, "name", sizeof("name") - 1, trace_span->name);
         zend_update_property_double(opencensus_trace_span_ce, &span, "startTime", sizeof("startTime") - 1, trace_span->start);
         zend_update_property_double(opencensus_trace_span_ce, &span, "endTime", sizeof("endTime") - 1, trace_span->stop);
+        zend_update_property_long(opencensus_trace_span_ce, &span, "kind", sizeof("kind") - 1, trace_span->kind);
 
         ZVAL_ARR(&label, trace_span->labels);
         zend_update_property(opencensus_trace_span_ce, &span, "labels", sizeof("labels") - 1, &label);

--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -21,12 +21,19 @@
  * namespace OpenCensus\Trace;
  *
  * class Span {
+ *   const SPAN_KIND_UNKNOWN = 0;
+ *   const SPAN_KIND_CLIENT = 1;
+ *   const SPAN_KIND_SERVER = 2;
+ *   const SPAN_KIND_PRODUCER = 3;
+ *   const SPAN_KIND_CONSUMER = 4;
+ *
  *   protected $name = "unknown";
  *   protected $spanId;
  *   protected $parentSpanId;
  *   protected $startTime;
  *   protected $endTime;
  *   protected $labels;
+ *   protected $kind;
  *
  *   public function __construct(array $spanOptions)
  *   {
@@ -45,7 +52,7 @@
  *     return $this->spanId;
  *   }
  *
- *   public function spanId()
+ *   public function parentSpanId()
  *   {
  *     return $this->parentSpanId;
  *   }
@@ -64,6 +71,11 @@
  *   {
  *     return $this->labels;
  *   }
+ *
+ *   public function kind()
+ *   {
+ *     return $this->kind;
+ *    }
  * }
  */
 

--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -75,6 +75,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_OpenCensusTraceSpan_construct, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, spanOptions, 0)
 ZEND_END_ARG_INFO();
 
+#define OPENCENSUS_TRACE_SPAN_KIND_UNKNOWN 0
+#define OPENCENSUS_TRACE_SPAN_KIND_CLIENT 1
+#define OPENCENSUS_TRACE_SPAN_KIND_SERVER 2
+#define OPENCENSUS_TRACE_SPAN_KIND_PRODUCER 3
+#define OPENCENSUS_TRACE_SPAN_KIND_CONSUMER 4
+
 /**
  * Initializer for OpenCensus\Trace\Span
  *
@@ -209,6 +215,8 @@ static zend_function_entry opencensus_trace_span_methods[] = {
     PHP_FE_END
 };
 
+#define REGISTER_TRACE_SPAN_CONSTANT(id) zend_declare_class_constant_long(opencensus_trace_span_ce, "SPAN_" #id, sizeof("SPAN_" #id) - 1, OPENCENSUS_TRACE_SPAN_##id);
+
 /* Module init handler for registering the OpenCensus\Trace\Span class */
 int opencensus_trace_span_minit(INIT_FUNC_ARGS) {
     zend_class_entry ce;
@@ -224,6 +232,12 @@ int opencensus_trace_span_minit(INIT_FUNC_ARGS) {
     zend_declare_property_null(opencensus_trace_span_ce, "startTime", sizeof("startTime") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
     zend_declare_property_null(opencensus_trace_span_ce, "endTime", sizeof("endTime") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
     zend_declare_property_null(opencensus_trace_span_ce, "labels", sizeof("labels") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
+
+    REGISTER_TRACE_SPAN_CONSTANT(KIND_UNKNOWN);
+    REGISTER_TRACE_SPAN_CONSTANT(KIND_CLIENT);
+    REGISTER_TRACE_SPAN_CONSTANT(KIND_SERVER);
+    REGISTER_TRACE_SPAN_CONSTANT(KIND_PRODUCER);
+    REGISTER_TRACE_SPAN_CONSTANT(KIND_CONSUMER);
 
     return SUCCESS;
 }

--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -75,12 +75,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_OpenCensusTraceSpan_construct, 0, 0, 1)
 	ZEND_ARG_ARRAY_INFO(0, spanOptions, 0)
 ZEND_END_ARG_INFO();
 
-#define OPENCENSUS_TRACE_SPAN_KIND_UNKNOWN 0
-#define OPENCENSUS_TRACE_SPAN_KIND_CLIENT 1
-#define OPENCENSUS_TRACE_SPAN_KIND_SERVER 2
-#define OPENCENSUS_TRACE_SPAN_KIND_PRODUCER 3
-#define OPENCENSUS_TRACE_SPAN_KIND_CONSUMER 4
-
 /**
  * Initializer for OpenCensus\Trace\Span
  *
@@ -203,6 +197,23 @@ static PHP_METHOD(OpenCensusTraceSpan, endTime) {
     RETURN_ZVAL(val, 1, 0);
 }
 
+/**
+ * Fetch the span kind
+ *
+ * @return int
+ */
+static PHP_METHOD(OpenCensusTraceSpan, kind) {
+    zval *val, rv;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    val = zend_read_property(opencensus_trace_span_ce, getThis(), "kind", sizeof("kind") - 1, 1, &rv);
+
+    RETURN_ZVAL(val, 1, 0);
+}
+
 /* Declare method entries for the OpenCensus\Trace\Span class */
 static zend_function_entry opencensus_trace_span_methods[] = {
     PHP_ME(OpenCensusTraceSpan, __construct, arginfo_OpenCensusTraceSpan_construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -212,6 +223,7 @@ static zend_function_entry opencensus_trace_span_methods[] = {
     PHP_ME(OpenCensusTraceSpan, labels, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(OpenCensusTraceSpan, startTime, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(OpenCensusTraceSpan, endTime, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, kind, NULL, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
 
@@ -231,6 +243,7 @@ int opencensus_trace_span_minit(INIT_FUNC_ARGS) {
     zend_declare_property_null(opencensus_trace_span_ce, "parentSpanId", sizeof("parentSpanId") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
     zend_declare_property_null(opencensus_trace_span_ce, "startTime", sizeof("startTime") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
     zend_declare_property_null(opencensus_trace_span_ce, "endTime", sizeof("endTime") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
+    zend_declare_property_null(opencensus_trace_span_ce, "kind", sizeof("kind") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
     zend_declare_property_null(opencensus_trace_span_ce, "labels", sizeof("labels") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
 
     REGISTER_TRACE_SPAN_CONSTANT(KIND_UNKNOWN);
@@ -310,6 +323,8 @@ int opencensus_trace_span_apply_span_options(opencensus_trace_span_t *span, zval
             span->start = Z_DVAL_P(v);
         } else if (strcmp(ZSTR_VAL(k), "name") == 0) {
             span->name = zend_string_copy(Z_STR_P(v));
+        } else if (strcmp(ZSTR_VAL(k), "kind") == 0) {
+            span->kind = Z_LVAL_P(v);
         }
     } ZEND_HASH_FOREACH_END();
     return SUCCESS;

--- a/ext/opencensus_trace_span.h
+++ b/ext/opencensus_trace_span.h
@@ -21,6 +21,11 @@
 
 extern zend_class_entry* opencensus_trace_span_ce;
 
+#define OPENCENSUS_TRACE_SPAN_KIND_UNKNOWN 0
+#define OPENCENSUS_TRACE_SPAN_KIND_CLIENT 1
+#define OPENCENSUS_TRACE_SPAN_KIND_SERVER 2
+#define OPENCENSUS_TRACE_SPAN_KIND_PRODUCER 3
+#define OPENCENSUS_TRACE_SPAN_KIND_CONSUMER 4
 
 // TraceSpan struct
 typedef struct opencensus_trace_span_t {
@@ -29,6 +34,7 @@ typedef struct opencensus_trace_span_t {
     double start;
     double stop;
     struct opencensus_trace_span_t *parent;
+    zend_long kind;
 
     // zend_string* => zval*
     HashTable *labels;

--- a/ext/package.xml
+++ b/ext/package.xml
@@ -57,6 +57,8 @@ This extension allows you to easily gather latency and other metadata by watchin
       <file name="function_callback_extra_arguments.phpt" role="test" />
       <file name="function_callback_wrong_return.phpt" role="test" />
       <file name="function_custom.phpt" role="test" />
+      <file name="function_kind_default.phpt" role="test" />
+      <file name="function_kind_specified.phpt" role="test" />
       <file name="inherit_context.phpt" role="test" />
       <file name="labels.phpt" role="test" />
       <file name="manual_spans.phpt" role="test" />
@@ -66,6 +68,8 @@ This extension allows you to easily gather latency and other metadata by watchin
       <file name="method_callback_arguments.phpt" role="test" />
       <file name="method_callback_scope.phpt" role="test" />
       <file name="method_custom.phpt" role="test" />
+      <file name="method_kind_default.phpt" role="test" />
+      <file name="method_kind_specified.phpt" role="test" />
       <file name="nested_spans.phpt" role="test" />
       <file name="non-string-labels-function-callback.phpt" role="test" />
       <file name="non-string-labels-function.phpt" role="test" />

--- a/ext/span.php
+++ b/ext/span.php
@@ -21,12 +21,19 @@ namespace OpenCensus\Trace;
  * This is the equivalent PHP class created by the opencensus C extension
  */
 class Span {
+    const SPAN_KIND_UNKNOWN = 0;
+    const SPAN_KIND_CLIENT = 1;
+    const SPAN_KIND_SERVER = 2;
+    const SPAN_KIND_PRODUCER = 3;
+    const SPAN_KIND_CONSUMER = 4;
+
     protected $name = "unknown";
     protected $spanId;
     protected $parentSpanId;
     protected $startTime;
     protected $endTime;
     protected $labels;
+    protected $kind;
 
     public function __construct(array $spanOptions)
     {
@@ -45,7 +52,7 @@ class Span {
         return $this->spanId;
     }
 
-    public function spanId()
+    public function parentSpanId()
     {
         return $this->parentSpanId;
     }
@@ -63,5 +70,10 @@ class Span {
     public function labels()
     {
         return $this->labels;
+    }
+
+    public function kind()
+    {
+        return $this->kind;
     }
 }

--- a/ext/tests/constants_test.phpt
+++ b/ext/tests/constants_test.phpt
@@ -3,11 +3,11 @@ OpenCensus Trace: Test Constants Defined
 --FILE--
 <?php
 
-var_dump(OPENCENSUS_TRACE_SPAN_KIND_UNKNOWN);
-var_dump(OPENCENSUS_TRACE_SPAN_KIND_CLIENT);
-var_dump(OPENCENSUS_TRACE_SPAN_KIND_SERVER);
-var_dump(OPENCENSUS_TRACE_SPAN_KIND_PRODUCER);
-var_dump(OPENCENSUS_TRACE_SPAN_KIND_CONSUMER);
+var_dump(OpenCensus\Trace\Span::SPAN_KIND_UNKNOWN);
+var_dump(OpenCensus\Trace\Span::SPAN_KIND_CLIENT);
+var_dump(OpenCensus\Trace\Span::SPAN_KIND_SERVER);
+var_dump(OpenCensus\Trace\Span::SPAN_KIND_PRODUCER);
+var_dump(OpenCensus\Trace\Span::SPAN_KIND_CONSUMER);
 
 ?>
 --EXPECT--

--- a/ext/tests/constants_test.phpt
+++ b/ext/tests/constants_test.phpt
@@ -1,0 +1,18 @@
+--TEST--
+OpenCensus Trace: Test Constants Defined
+--FILE--
+<?php
+
+var_dump(OPENCENSUS_TRACE_SPAN_KIND_UNKNOWN);
+var_dump(OPENCENSUS_TRACE_SPAN_KIND_CLIENT);
+var_dump(OPENCENSUS_TRACE_SPAN_KIND_SERVER);
+var_dump(OPENCENSUS_TRACE_SPAN_KIND_PRODUCER);
+var_dump(OPENCENSUS_TRACE_SPAN_KIND_CONSUMER);
+
+?>
+--EXPECT--
+int(0)
+int(1)
+int(2)
+int(3)
+int(4)

--- a/ext/tests/function_kind_default.phpt
+++ b/ext/tests/function_kind_default.phpt
@@ -1,0 +1,19 @@
+--TEST--
+OpenCensus Trace: Default span kind
+--FILE--
+<?php
+
+require_once(__DIR__ . '/common.php');
+
+// 1: Sanity test a simple profile run
+opencensus_trace_function("bar", ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer']]);
+bar();
+$traces = opencensus_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+
+echo "Span kind is '{$span->kind()}'";
+?>
+--EXPECT--
+Number of traces: 1
+Span kind is '0'

--- a/ext/tests/function_kind_specified.phpt
+++ b/ext/tests/function_kind_specified.phpt
@@ -1,0 +1,19 @@
+--TEST--
+OpenCensus Trace: Provided span kind
+--FILE--
+<?php
+
+require_once(__DIR__ . '/common.php');
+
+// 1: Sanity test a simple profile run
+opencensus_trace_function("bar", ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer'], 'kind' => 1]);
+bar();
+$traces = opencensus_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+
+echo "Span kind is '{$span->kind()}'";
+?>
+--EXPECT--
+Number of traces: 1
+Span kind is '1'

--- a/ext/tests/manual_spans_default_options.phpt
+++ b/ext/tests/manual_spans_default_options.phpt
@@ -28,6 +28,7 @@ Array
             [parentSpanId:protected] =>%s
             [startTime:protected] => %d.%d
             [endTime:protected] => %d.%d
+            [kind:protected] => %d
             [labels:protected] => Array
                 (
                 )
@@ -41,6 +42,7 @@ Array
             [parentSpanId:protected] => %d
             [startTime:protected] => %d.%d
             [endTime:protected] => %d.%d
+            [kind:protected] => %d
             [labels:protected] => Array
                 (
                 )

--- a/ext/tests/method_kind_default.phpt
+++ b/ext/tests/method_kind_default.phpt
@@ -1,0 +1,20 @@
+--TEST--
+OpenCensus Trace: Default span kind
+--FILE--
+<?php
+
+require_once(__DIR__ . '/common.php');
+
+// 1: Sanity test a simple profile run
+opencensus_trace_method("Foo", "bar", ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer']]);
+$f = new Foo();
+$f->bar();
+$traces = opencensus_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+
+echo "Span kind is '{$span->kind()}'";
+?>
+--EXPECT--
+Number of traces: 1
+Span kind is '0'

--- a/ext/tests/method_kind_specified.phpt
+++ b/ext/tests/method_kind_specified.phpt
@@ -1,0 +1,20 @@
+--TEST--
+OpenCensus Trace: Provided span kind
+--FILE--
+<?php
+
+require_once(__DIR__ . '/common.php');
+
+// 1: Sanity test a simple profile run
+opencensus_trace_method("Foo", "bar", ['name' => 'foo', 'startTime' => 0.1, 'labels' => ['asdf' => 'qwer'], 'kind' => 1]);
+$f = new Foo();
+$f->bar();
+$traces = opencensus_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+$span = $traces[0];
+
+echo "Span kind is '{$span->kind()}'";
+?>
+--EXPECT--
+Number of traces: 1
+Span kind is '1'

--- a/ext/tests/span_class.phpt
+++ b/ext/tests/span_class.phpt
@@ -9,7 +9,8 @@ $span = new OpenCensus\Trace\Span([
     'spanId' => 1234,
     'name' => 'foo',
     'startTime' => 12345.1,
-    'endTime' => 23456.2
+    'endTime' => 23456.2,
+    'kind' => 1
 ]);
 
 echo "Span id: {$span->spanId()}\n";
@@ -20,9 +21,12 @@ echo "Span startTime: {$span->startTime()}\n";
 
 echo "Span endTime: {$span->endTime()}\n";
 
+echo "Span kind: {$span->kind()}\n";
+
 ?>
 --EXPECT--
 Span id: 1234
 Span name: foo
 Span startTime: 12345.1
 Span endTime: 23456.2
+Span kind: 1

--- a/src/Trace/TraceSpan.php
+++ b/src/Trace/TraceSpan.php
@@ -31,6 +31,12 @@ class TraceSpan
      */
     private $info = [];
 
+    const SPAN_KIND_UNKNOWN = 0;
+    const SPAN_KIND_CLIENT = 1;
+    const SPAN_KIND_SERVER = 2;
+    const SPAN_KIND_PRODUCER = 3;
+    const SPAN_KIND_CONSUMER = 4;
+
     /**
      * Instantiate a new Span instance.
      *
@@ -49,6 +55,8 @@ class TraceSpan
      *      @type int $parentSpanId ID of the parent span if any.
      *      @type array $labels Associative array of $label => $value
      *            to attach to this span.
+     *      @type int $kind The kind of span. One of SPAN_KIND_UNKNOWN|SPAN_KIND_CLIENT|SPAN_KIND_SERVER|
+     *            SPAN_KIND_CONSUMER|SPAN_KIND_PRODUCER. **Defaults to** SPAN_KIND_UNKNOWN,
      * }
      */
     public function __construct($options = [])
@@ -72,6 +80,13 @@ class TraceSpan
             unset($options['spanId']);
         } else {
             $this->info['spanId'] = $this->generateSpanId();
+        }
+
+        if (array_key_exists('kind', $options)) {
+            $this->info['kind'] = $options['kind'];
+            unset($options['kind']);
+        } else {
+            $this->info['kind'] = self::SPAN_KIND_UNKNOWN;
         }
 
         if (array_key_exists('name', $options)) {
@@ -175,6 +190,16 @@ class TraceSpan
         return array_key_exists('labels', $this->info)
             ? $this->info['labels']
             : [];
+    }
+
+    /**
+     * Retrieve the kind of span
+     *
+     * @return int One of SPAN_KIND_UNKNOWN|SPAN_KIND_CLIENT|SPAN_KIND_SERVER|SPAN_KIND_CONSUMER|SPAN_KIND_PRODUCER
+     */
+    public function kind()
+    {
+        return $this->info['kind'];
     }
 
     /**

--- a/tests/unit/Trace/Reporter/ZipkinReporterTest.php
+++ b/tests/unit/Trace/Reporter/ZipkinReporterTest.php
@@ -100,7 +100,7 @@ class ZipkinReporterTest extends \PHPUnit_Framework_TestCase
         // default unknown spans to client send/receive
         $this->assertEquals(['cs', 'cr'], array_map($annotationValue, $spans[0]['annotations']));
         $this->assertEquals(['cs', 'cr'], array_map($annotationValue, $spans[1]['annotations']));
-        $this->assertEquals(['ss', 'sr'], array_map($annotationValue, $spans[2]['annotations']));
+        $this->assertEquals(['sr', 'ss'], array_map($annotationValue, $spans[2]['annotations']));
         $this->assertEquals(['ms'], array_map($annotationValue, $spans[3]['annotations']));
         $this->assertEquals(['mr'], array_map($annotationValue, $spans[4]['annotations']));
     }

--- a/tests/unit/Trace/Reporter/ZipkinReporterTest.php
+++ b/tests/unit/Trace/Reporter/ZipkinReporterTest.php
@@ -21,6 +21,7 @@ use OpenCensus\Trace\Reporter\ZipkinReporter;
 use OpenCensus\Trace\TraceContext;
 use OpenCensus\Trace\TraceSpan;
 use OpenCensus\Trace\Tracer\TracerInterface;
+use OpenCensus\Trace\Tracer\ContextTracer;
 use Prophecy\Argument;
 
 /**
@@ -76,5 +77,31 @@ class ZipkinReporterTest extends \PHPUnit_Framework_TestCase
                 $this->assertInternalType('string', $annotation['value']);
             }
         }
+    }
+
+    public function testSpanKind()
+    {
+        $tracer = new ContextTracer(new TraceContext('testtraceid'));
+        $tracer->inSpan(['name' => 'main'], function () use ($tracer) {
+            $tracer->inSpan(['name' => 'span1', 'kind' => TraceSpan::SPAN_KIND_CLIENT], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span2', 'kind' => TraceSpan::SPAN_KIND_SERVER], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span3', 'kind' => TraceSpan::SPAN_KIND_PRODUCER], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span4', 'kind' => TraceSpan::SPAN_KIND_CONSUMER], 'usleep', [1]);
+        });
+
+        $reporter = new ZipkinReporter('myapp', 'localhost', 9411);
+        $spans = $reporter->convertSpans($tracer);
+
+        $annotationValue = function ($annotation) {
+            return $annotation['value'];
+        };
+
+        $this->assertCount(5, $spans);
+        // default unknown spans to client send/receive
+        $this->assertEquals(['cs', 'cr'], array_map($annotationValue, $spans[0]['annotations']));
+        $this->assertEquals(['cs', 'cr'], array_map($annotationValue, $spans[1]['annotations']));
+        $this->assertEquals(['ss', 'sr'], array_map($annotationValue, $spans[2]['annotations']));
+        $this->assertEquals(['ms'], array_map($annotationValue, $spans[3]['annotations']));
+        $this->assertEquals(['mr'], array_map($annotationValue, $spans[4]['annotations']));
     }
 }

--- a/tests/unit/Trace/TraceSpanTest.php
+++ b/tests/unit/Trace/TraceSpanTest.php
@@ -108,6 +108,21 @@ class TraceSpanTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(\DateTimeInterface::class, $info['endTime']);
     }
 
+    public function testGeneratesDefaultKind()
+   {
+       $traceSpan = new TraceSpan();
+       $info = $traceSpan->info();
+       $this->assertArrayHasKey('kind', $info);
+       $this->assertEquals(TraceSpan::SPAN_KIND_UNKNOWN, $info['kind']);
+   }
+   public function testReadsKind()
+   {
+       $traceSpan = new TraceSpan(['kind' => TraceSpan::SPAN_KIND_CLIENT]);
+       $info = $traceSpan->info();
+       $this->assertArrayHasKey('kind', $info);
+       $this->assertEquals(TraceSpan::SPAN_KIND_CLIENT, $info['kind']);
+   }
+
     public function testIgnoresUnknownFields()
     {
         $traceSpan = new TraceSpan(['extravalue' => 'something']);


### PR DESCRIPTION
The tracers will accept an optional `kind` attribute whose value is an enumerable value.
The reporters are responsible for mapping the recorded span kind to its representation of span kind.

Note that both the extension and the php library both need to implement this.

Fixes #18 