### PR TITLE
Capture stacktrace

### DIFF
--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -242,14 +242,12 @@ static void opencensus_trace_execute_callback(opencensus_trace_span_t *span, zen
  */
 static opencensus_trace_span_t *opencensus_trace_begin(zend_string *function_name, zend_execute_data *execute_data TSRMLS_DC)
 {
-    zval backtrace;
     opencensus_trace_span_t *span = opencensus_trace_span_alloc();
 
-    zend_fetch_debug_backtrace(&backtrace, 1, DEBUG_BACKTRACE_IGNORE_ARGS);
+    zend_fetch_debug_backtrace(&span->backtrace, 1, DEBUG_BACKTRACE_IGNORE_ARGS, 0);
 
     span->start = opencensus_now();
     span->name = zend_string_copy(function_name);
-    ZVAL_ZVAL(&span->backtrace, &backtrace, 1, 0);
 
 #if PHP_VERSION_ID < 70100
     if (!BG(mt_rand_is_seeded)) {

--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -197,6 +197,23 @@ static PHP_METHOD(OpenCensusTraceSpan, endTime) {
     RETURN_ZVAL(val, 1, 0);
 }
 
+/**
+ * Fetch the backtrace from the moment the span was started
+ *
+ * @return array
+ */
+static PHP_METHOD(OpenCensusTraceSpan, backtrace) {
+    zval *val, rv;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    val = zend_read_property(opencensus_trace_span_ce, getThis(), "backtrace", sizeof("backtrace") - 1, 1, &rv);
+
+    RETURN_ZVAL(val, 1, 0);
+}
+
 /* Declare method entries for the OpenCensus\Trace\Span class */
 static zend_function_entry opencensus_trace_span_methods[] = {
     PHP_ME(OpenCensusTraceSpan, __construct, arginfo_OpenCensusTraceSpan_construct, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -206,6 +223,7 @@ static zend_function_entry opencensus_trace_span_methods[] = {
     PHP_ME(OpenCensusTraceSpan, labels, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(OpenCensusTraceSpan, startTime, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(OpenCensusTraceSpan, endTime, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, backtrace, NULL, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
 
@@ -224,6 +242,7 @@ int opencensus_trace_span_minit(INIT_FUNC_ARGS) {
     zend_declare_property_null(opencensus_trace_span_ce, "startTime", sizeof("startTime") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
     zend_declare_property_null(opencensus_trace_span_ce, "endTime", sizeof("endTime") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
     zend_declare_property_null(opencensus_trace_span_ce, "labels", sizeof("labels") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
+    zend_declare_property_null(opencensus_trace_span_ce, "backtrace", sizeof("backtrace") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
 
     return SUCCESS;
 }

--- a/ext/opencensus_trace_span.h
+++ b/ext/opencensus_trace_span.h
@@ -29,6 +29,7 @@ typedef struct opencensus_trace_span_t {
     double start;
     double stop;
     struct opencensus_trace_span_t *parent;
+    zval backtrace;
 
     // zend_string* => zval*
     HashTable *labels;

--- a/ext/tests/backtrace_test.phpt
+++ b/ext/tests/backtrace_test.phpt
@@ -1,0 +1,47 @@
+--TEST--
+OpenCensus Trace: Customize the trace span options for a function
+--FILE--
+<?php
+
+function abcd()
+{
+    return 3;
+}
+
+function myFunction()
+{
+    abcd();
+}
+
+opencensus_trace_function('abcd');
+myFunction();
+
+$traces = opencensus_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+
+foreach ($traces as $span) {
+    var_dump($span->backtrace());
+}
+?>
+--EXPECTF--
+Number of traces: 1
+array(2) {
+  [0]=>
+  array(3) {
+    ["file"]=>
+    string(%d) "%s/backtrace_test.php"
+    ["line"]=>
+    int(10)
+    ["function"]=>
+    string(4) "abcd"
+  }
+  [1]=>
+  array(3) {
+    ["file"]=>
+    string(%d) "%s/backtrace_test.php"
+    ["line"]=>
+    int(14)
+    ["function"]=>
+    string(10) "myFunction"
+  }
+}

--- a/ext/tests/manual_spans_default_options.phpt
+++ b/ext/tests/manual_spans_default_options.phpt
@@ -32,6 +32,10 @@ Array
                 (
                 )
 
+            [backtrace:protected] => Array
+                (
+                )
+
         )
 
     [1] => OpenCensus\Trace\Span Object
@@ -42,6 +46,10 @@ Array
             [startTime:protected] => %d.%d
             [endTime:protected] => %d.%d
             [labels:protected] => Array
+                (
+                )
+
+            [backtrace:protected] => Array
                 (
                 )
 

--- a/src/Trace/Reporter/GoogleCloudReporter.php
+++ b/src/Trace/Reporter/GoogleCloudReporter.php
@@ -211,17 +211,42 @@ class GoogleCloudReporter implements ReporterInterface
             $kind = array_key_exists($span->kind(), $spanKindMap)
                 ? $spanKindMap[$span->kind()]
                 :  TraceSpan::SPAN_KIND_UNSPECIFIED;
+            $labels = $span->labels();
+            $labels[self::STACKTRACE] = $this->formatBacktrace($span->backtrace());
             return new TraceSpan([
                 'name' => $span->name(),
                 'startTime' => $span->startTime(),
                 'endTime' => $span->endTime(),
                 'spanId' => $span->spanId(),
                 'parentSpanId' => $span->parentSpanId(),
-                'labels' => $span->labels(),
-                'kind' => $kind
+                'labels' => $labels,
+                'kind' => $kind,
             ]);
             $span->info();
         }, $tracer->spans());
+    }
+
+    private function formatBacktrace($bt)
+    {
+        return json_encode([
+            'stack_frame' => array_map([$this, 'mapStackframe'], $bt)
+        ]);
+    }
+
+    private function mapStackframe($sf)
+    {
+        // file and line should always be set
+        $data = [
+            'file_name' => $sf['file'],
+            'line_number' => $sf['line']
+        ];
+        if (isset($sf['function'])) {
+            $data['method_name'] = $sf['function'];
+        }
+        if (isset($sf['class'])) {
+            $data['class_name'] = $sf['class'];
+        }
+        return $data;
     }
 
     /**

--- a/src/Trace/Reporter/GoogleCloudReporter.php
+++ b/src/Trace/Reporter/GoogleCloudReporter.php
@@ -236,10 +236,13 @@ class GoogleCloudReporter implements ReporterInterface
     private function mapStackframe($sf)
     {
         // file and line should always be set
-        $data = [
-            'file_name' => $sf['file'],
-            'line_number' => $sf['line']
-        ];
+        $data = [];
+        if (isset($sf['line'])) {
+            $data['line_number'] = $sf['line'];
+        }
+        if (isset($sf['file'])) {
+            $data['file_name'] = $sf['file'];
+        }
         if (isset($sf['function'])) {
             $data['method_name'] = $sf['function'];
         }

--- a/src/Trace/TraceSpan.php
+++ b/src/Trace/TraceSpan.php
@@ -300,9 +300,11 @@ class TraceSpan
      */
     private function generateBacktrace()
     {
-        return array_filter(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), function ($bt) {
-            return !array_key_exists('class', $bt) || substr($bt['class'], 0, 16) != 'OpenCensus\Trace';
-        });
+        return array_values(
+            array_filter(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), function ($bt) {
+                return !array_key_exists('class', $bt) || substr($bt['class'], 0, 16) != 'OpenCensus\Trace';
+            })
+        );
     }
 
     /**

--- a/tests/unit/Trace/TraceSpanTest.php
+++ b/tests/unit/Trace/TraceSpanTest.php
@@ -135,7 +135,7 @@ class TraceSpanTest extends \PHPUnit_Framework_TestCase
         $traceSpan = new TraceSpan();
         $this->assertInternalType('array', $traceSpan->backtrace());
         $this->assertTrue(count($traceSpan->backtrace()) > 0);
-        $stackframe = reset($traceSpan->backtrace()); // get the first item
+        $stackframe = $traceSpan->backtrace()[0];
         $this->assertEquals('testGeneratesBacktrace', $stackframe['function']);
         $this->assertEquals(self::class, $stackframe['class']);
     }
@@ -155,7 +155,7 @@ class TraceSpanTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $this->assertCount(1, $traceSpan->backtrace());
-        $stackframe = reset($traceSpan->backtrace()); // get the first item
+        $stackframe = $traceSpan->backtrace()[0];
         $this->assertEquals('asdf', $stackframe['function']);
         $this->assertEquals('Foo', $stackframe['class']);
     }

--- a/tests/unit/Trace/TraceSpanTest.php
+++ b/tests/unit/Trace/TraceSpanTest.php
@@ -115,6 +115,36 @@ class TraceSpanTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('extravalue', $info);
     }
 
+    public function testGeneratesBacktrace()
+    {
+        $traceSpan = new TraceSpan();
+        $this->assertInternalType('array', $traceSpan->backtrace());
+        $this->assertTrue(count($traceSpan->backtrace()) > 0);
+        $stackframe = reset($traceSpan->backtrace()); // get the first item
+        $this->assertEquals('testGeneratesBacktrace', $stackframe['function']);
+        $this->assertEquals(self::class, $stackframe['class']);
+    }
+
+    public function testOverrideBacktrace()
+    {
+        $backtrace = [
+            [
+                'class' => 'Foo',
+                'line' => 1234,
+                'function' => 'asdf',
+                'type' => '::'
+            ]
+        ];
+        $traceSpan = new TraceSpan([
+            'backtrace' => $backtrace
+        ]);
+
+        $this->assertCount(1, $traceSpan->backtrace());
+        $stackframe = reset($traceSpan->backtrace()); // get the first item
+        $this->assertEquals('asdf', $stackframe['function']);
+        $this->assertEquals('Foo', $stackframe['class']);
+    }
+
     /**
      * @dataProvider timestampFields
      */


### PR DESCRIPTION
The tracers should capture the `debug_backtrace` output at the moment a span is started.
The reporters are responsible for mapping the backtrace output to its representation of the stacktrace.

Note that both the extension and the php library both need to implement this.

Fixes #9 