### PR TITLE
Fix extension stacktrace report

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,5 @@ WORKDIR /build
 
 RUN composer install && \
     vendor/bin/phpcs --standard=./phpcs-ruleset.xml && \
-    vendor/bin/phpunit
+    vendor/bin/phpunit && \
+    php -d extension=opencensus.so vendor/bin/phpunit

--- a/src/Trace/TraceSpan.php
+++ b/src/Trace/TraceSpan.php
@@ -83,10 +83,10 @@ class TraceSpan
         }
 
         if (array_key_exists('backtrace', $options)) {
-            $this->info['backtrace'] = $options['backtrace'];
+            $this->info['backtrace'] = $this->filterBacktrace($options['backtrace']);
             unset($options['backtrace']);
         } else {
-            $this->info['backtrace'] = $this->generateBacktrace();
+            $this->info['backtrace'] = $this->filterBacktrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
         }
 
         if (array_key_exists('kind', $options)) {
@@ -298,10 +298,10 @@ class TraceSpan
      *
      * @return array
      */
-    private function generateBacktrace()
+    private function filterBacktrace($backtrace)
     {
         return array_values(
-            array_filter(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), function ($bt) {
+            array_filter($backtrace, function ($bt) {
                 return !array_key_exists('class', $bt) || substr($bt['class'], 0, 16) != 'OpenCensus\Trace';
             })
         );

--- a/src/Trace/Tracer/ExtensionTracer.php
+++ b/src/Trace/Tracer/ExtensionTracer.php
@@ -114,7 +114,8 @@ class ExtensionTracer implements TracerInterface
                 'parentSpanId' => $span->parentSpanId(),
                 'startTime' => $span->startTime(),
                 'endTime' => $span->endTime(),
-                'labels' => $span->labels()
+                'labels' => $span->labels(),
+                'backtrace' => $span->backtrace()
             ]);
         }, opencensus_trace_list());
     }

--- a/tests/unit/Trace/Tracer/ContextTracerTest.php
+++ b/tests/unit/Trace/Tracer/ContextTracerTest.php
@@ -36,7 +36,7 @@ class ContextTracerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('traceid', $context->traceId());
         $this->assertEquals($parentSpanId, $context->spanId());
 
-        $tracer->inSpan(['name' => 'test'], function() use ($tracer, $parentSpanId) {
+        $tracer->inSpan(['name' => 'test'], function () use ($tracer, $parentSpanId) {
             $context = $tracer->context();
             $this->assertNotEquals($parentSpanId, $context->spanId());
         });
@@ -80,5 +80,15 @@ class ContextTracerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('root', $span->name());
         $info = $span->info();
         $this->assertEquals('bar', $info['labels']['foo']);
+    }
+
+    public function testPersistsBacktrace()
+    {
+        $tracer = new ContextTracer();
+        $tracer->inSpan(['name' => 'test'], function () {});
+        $span = $tracer->spans()[0];
+        $stackframe = $span->backtrace()[0];
+        $this->assertEquals('testPersistsBacktrace', $stackframe['function']);
+        $this->assertEquals(self::class, $stackframe['class']);
     }
 }

--- a/tests/unit/Trace/Tracer/ContextTracerTest.php
+++ b/tests/unit/Trace/Tracer/ContextTracerTest.php
@@ -27,24 +27,25 @@ class ContextTracerTest extends \PHPUnit_Framework_TestCase
 {
     public function testMaintainsContext()
     {
-        $initialContext = new TraceContext('traceid', 'spanid');
+        $parentSpanId = 12345;
+        $initialContext = new TraceContext('traceid', $parentSpanId);
 
         $tracer = new ContextTracer($initialContext);
         $context = $tracer->context();
 
         $this->assertEquals('traceid', $context->traceId());
-        $this->assertEquals('spanid', $context->spanId());
+        $this->assertEquals($parentSpanId, $context->spanId());
 
-        $tracer->inSpan(['name' => 'test'], function() use ($tracer) {
+        $tracer->inSpan(['name' => 'test'], function() use ($tracer, $parentSpanId) {
             $context = $tracer->context();
-            $this->assertNotEquals('spanid', $context->spanId());
+            $this->assertNotEquals($parentSpanId, $context->spanId());
         });
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
         $span = $spans[0];
         $this->assertEquals('test', $span->name());
-        $this->assertEquals('spanid', $span->parentSpanId());
+        $this->assertEquals($parentSpanId, $span->parentSpanId());
     }
 
     public function testAddsLabelsToCurrentSpan()

--- a/tests/unit/Trace/Tracer/ExtentionTracerTest.php
+++ b/tests/unit/Trace/Tracer/ExtentionTracerTest.php
@@ -44,7 +44,7 @@ class ExtensionTracerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('traceid', $context->traceId());
         $this->assertEquals($parentSpanId, $context->spanId());
 
-        $tracer->inSpan(['name' => 'test'], function() use ($tracer, $parentSpanId) {
+        $tracer->inSpan(['name' => 'test'], function () use ($tracer, $parentSpanId) {
             $context = $tracer->context();
             $this->assertNotEquals($parentSpanId, $context->spanId());
         });
@@ -88,5 +88,15 @@ class ExtensionTracerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('root', $span->name());
         $info = $span->info();
         $this->assertEquals('bar', $info['labels']['foo']);
+    }
+
+    public function testPersistsBacktrace()
+    {
+        $tracer = new ExtensionTracer();
+        $tracer->inSpan(['name' => 'test'], function () {});
+        $span = $tracer->spans()[0];
+        $stackframe = $span->backtrace()[0];
+        $this->assertEquals('testPersistsBacktrace', $stackframe['function']);
+        $this->assertEquals(self::class, $stackframe['class']);
     }
 }


### PR DESCRIPTION
Run php tests with and without the extension installed.
The backtrace captured by the extension is not being persisted to the returned spans.

Fixes #22 