### PR TITLE
Change Stackdriver Trace /agent label to "opencensus-php"

### DIFF
--- a/src/Trace/Reporter/GoogleCloudReporter.php
+++ b/src/Trace/Reporter/GoogleCloudReporter.php
@@ -302,7 +302,7 @@ class GoogleCloudReporter implements ReporterInterface
             }
         }
         $tracer->addRootLabel(self::PID, '' . getmypid());
-        $tracer->addRootLabel(self::AGENT, 'opencensus ' . self::VERSION);
+        $tracer->addRootLabel(self::AGENT, 'opencensus-php ' . self::VERSION);
     }
 
     private function detectKey(array $keys, array $array)


### PR DESCRIPTION
This distinguishes it from other opencensus language libraries like "opencensus-java", etc.

@chingor13 