### PR TITLE
Renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ $ composer require opencensus/opencensus
 
 ```php
 use OpenCensus\Trace\RequestTracer;
-use OpenCensus\Trace\Reporter\EchoReporter;
+use OpenCensus\Trace\Exporter\EchoExporter;
 
-RequestTracer::start(new EchoReporter());
+RequestTracer::start(new EchoExporter());
 ```
 
 ### PHP Extension
@@ -42,21 +42,21 @@ extension=opencensus.so
 
 ### Reporting Traces
 
-The above sample uses the `EchoReporter` to dump trace results to the
+The above sample uses the `EchoExporter` to dump trace results to the
 bottom of the webpage.
 
-If you would like to provide your own reporter, create a class that implements `ReporterInterface`.
+If you would like to provide your own reporter, create a class that implements `ExporterInterface`.
 
 #### Currently implemented reporters
 
 | Class | Description |
 | ----- | ----------- |
-| [EchoReporter](src/Trace/Reporter/EchoReporter.php) | Output the collected spans to stdout |
-| [FileReporter](src/Trace/Reporter/FileReporter.php) | Output JSON encoded spans to a file |
-| [GoogleCloudReporter](src/Trace/Reporter/GoogleCloudReporter.php) | Report traces to Google Cloud Stackdriver Trace |
-| [LoggerReporter](src/Trace/Reporter/LoggerReporter.php) | Reporter JSON encoded spans to a PSR-3 logger |
-| [NullReporter](scr/Trace/Reporter/NullReporter.php) | No-op |
-| [ZipkinReporter](src/Trace/Reporter/ZipkinReporter.php) | Report collected spans to a Zipkin server |
+| [EchoExporter](src/Trace/Exporter/EchoExporter.php) | Output the collected spans to stdout |
+| [FileExporter](src/Trace/Exporter/FileExporter.php) | Output JSON encoded spans to a file |
+| [GoogleCloudExporter](src/Trace/Exporter/GoogleCloudExporter.php) | Report traces to Google Cloud Stackdriver Trace |
+| [LoggerExporter](src/Trace/Exporter/LoggerExporter.php) | Exporter JSON encoded spans to a PSR-3 logger |
+| [NullExporter](scr/Trace/Exporter/NullExporter.php) | No-op |
+| [ZipkinExporter](src/Trace/Exporter/ZipkinExporter.php) | Report collected spans to a Zipkin server |
 
 ### Sampling Rate
 
@@ -68,12 +68,12 @@ The preferred sampler is the `QpsSampler` (Queries Per Second). This sampler imp
 requires a PSR-6 cache implementation to function.
 
 ```php
-use OpenCensus\Trace\Reporter\EchoReporter;
+use OpenCensus\Trace\Exporter\EchoExporter;
 use OpenCensus\Trace\Sampler\QpsSampler;
 
 $cache = new SomeCacheImplementation();
 $sampler = new QpsSampler($cache, ['rate' => 0.1]); // sample 0.1 requests per second
-RequestTracer::start(new EchoReporter(), ['sampler' => $sampler]);
+RequestTracer::start(new EchoExporter(), ['sampler' => $sampler]);
 ```
 
 Please note: While required for the `QpsSampler`, a PSR-6 implementation is
@@ -96,11 +96,11 @@ percentage of requests.
 | [ProbabilitySampler](src/Trace/Sampler/ProbabilitySampler.php) | Trace X percent of requests. |
 
 ```php
-use OpenCensus\Trace\Reporter\EchoReporter;
+use OpenCensus\Trace\Exporter\EchoExporter;
 use OpenCensus\Trace\Sampler\ProbabilitySampler;
 
 $sampler = new ProbabilitySampler(0.1); // sample 10% of requests
-RequestTracer::start(new EchoReporter(), ['sampler' => $sampler]);
+RequestTracer::start(new EchoExporter(), ['sampler' => $sampler]);
 ```
 
 If you would like to provide your own sampler, create a class that implements `SamplerInterface`.

--- a/README.md
+++ b/README.md
@@ -83,23 +83,23 @@ dependency to fulfill this requirement. For PSR-6 implementations, please see th
 If the APCu extension is available (available on Google AppEngine Flexible Environment)
 and you include the cache/apcu-adapter composer package, we will set up the cache for you.
 
-You can also choose to use the `RandomSampler` which simply samples a flat
+You can also choose to use the `ProbabilitySampler` which simply samples a flat
 percentage of requests.
 
 #### Currently implemented samplers
 
 | Class | Description |
 | ----- | ----------- |
-| [AlwaysOffSampler](src/Trace/Sampler/AlwaysOffSampler.php) | Never trace any requests |
-| [AlwaysOnSampler](src/Trace/Sampler/AlwaysOnSampler.php) | Trace all requests |
+| [NeverSampleSampler](src/Trace/Sampler/NeverSampleSampler.php) | Never trace any requests |
+| [AlwaysSampleSampler](src/Trace/Sampler/AlwaysSampleSampler.php) | Trace all requests |
 | [QpsSampler](src/Trace/Sampler/QpsSampler.php) | Trace X requests per second. Requires a PSR-6 cache implementation |
-| [RandomSampler](src/Trace/Sampler/RandomSampler.php) | Trace X percent of requests. |
+| [ProbabilitySampler](src/Trace/Sampler/ProbabilitySampler.php) | Trace X percent of requests. |
 
 ```php
 use OpenCensus\Trace\Reporter\EchoReporter;
-use OpenCensus\Trace\Sampler\RandomSampler;
+use OpenCensus\Trace\Sampler\ProbabilitySampler;
 
-$sampler = new RandomSampler(0.1); // sample 10% of requests
+$sampler = new ProbabilitySampler(0.1); // sample 10% of requests
 RequestTracer::start(new EchoReporter(), ['sampler' => $sampler]);
 ```
 

--- a/src/Trace/Exporter/EchoExporter.php
+++ b/src/Trace/Exporter/EchoExporter.php
@@ -15,31 +15,16 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Trace\Reporter;
+namespace OpenCensus\Trace\Exporter;
 
 use OpenCensus\Trace\Tracer\TracerInterface;
 
 /**
- * This implementation of the ReporterInterface appends a json
- * representation of the trace to a file.
+ * This implementation of the ExporterInterface uses `print_r` to output
+ * the trace's representation to stdout.
  */
-class FileReporter implements ReporterInterface
+class EchoExporter implements ExporterInterface
 {
-    /**
-     * @var string The path to the output file.
-     */
-    private $filename;
-
-    /**
-     * Create a new EchoReporter
-     *
-     * @param string $filename The path to the output file.
-     */
-    public function __construct($filename)
-    {
-        $this->filename = $filename;
-    }
-
     /**
      * Report the provided Trace to a backend.
      *
@@ -48,6 +33,7 @@ class FileReporter implements ReporterInterface
      */
     public function report(TracerInterface $tracer)
     {
-        return file_put_contents($this->filename, json_encode($tracer->spans()) . PHP_EOL, FILE_APPEND) !== false;
+        print_r($tracer->spans());
+        return true;
     }
 }

--- a/src/Trace/Exporter/ExporterInterface.php
+++ b/src/Trace/Exporter/ExporterInterface.php
@@ -15,23 +15,20 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Trace\Reporter;
+namespace OpenCensus\Trace\Exporter;
 
 use OpenCensus\Trace\Tracer\TracerInterface;
 
 /**
- * This implementation of the ReporterInterface does nothing.
+ * The ExporterInterface allows you to swap out the Trace reporting mechanism
  */
-class NullReporter implements ReporterInterface
+interface ExporterInterface
 {
     /**
-     * Does nothing.
+     * Report the provided Trace to a backend.
      *
      * @param  TracerInterface $tracer
      * @return bool
      */
-    public function report(TracerInterface $tracer)
-    {
-        return true;
-    }
+    public function report(TracerInterface $tracer);
 }

--- a/src/Trace/Exporter/FileExporter.php
+++ b/src/Trace/Exporter/FileExporter.php
@@ -15,20 +15,39 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Trace\Reporter;
+namespace OpenCensus\Trace\Exporter;
 
 use OpenCensus\Trace\Tracer\TracerInterface;
 
 /**
- * The ReporterInterface allows you to swap out the Trace reporting mechanism
+ * This implementation of the ExporterInterface appends a json
+ * representation of the trace to a file.
  */
-interface ReporterInterface
+class FileExporter implements ExporterInterface
 {
+    /**
+     * @var string The path to the output file.
+     */
+    private $filename;
+
+    /**
+     * Create a new EchoExporter
+     *
+     * @param string $filename The path to the output file.
+     */
+    public function __construct($filename)
+    {
+        $this->filename = $filename;
+    }
+
     /**
      * Report the provided Trace to a backend.
      *
      * @param  TracerInterface $tracer
      * @return bool
      */
-    public function report(TracerInterface $tracer);
+    public function report(TracerInterface $tracer)
+    {
+        return file_put_contents($this->filename, json_encode($tracer->spans()) . PHP_EOL, FILE_APPEND) !== false;
+    }
 }

--- a/src/Trace/Exporter/GoogleCloudExporter.php
+++ b/src/Trace/Exporter/GoogleCloudExporter.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Trace\Reporter;
+namespace OpenCensus\Trace\Exporter;
 
 use Google\Cloud\Core\Batch\BatchRunner;
 use Google\Cloud\Core\Batch\BatchTrait;
@@ -25,15 +25,15 @@ use OpenCensus\Trace\Tracer\TracerInterface;
 use OpenCensus\Trace\TraceSpan as OpenCensusTraceSpan;
 
 /**
- * This implementation of the ReporterInterface use the BatchRunner to provide
+ * This implementation of the ExporterInterface use the BatchRunner to provide
  * reporting of Traces and their TraceSpans to Google Cloud Stackdriver Trace.
  *
  * Example:
  * ```
  * use OpenCensus\Trace\RequestTracer;
- * use OpenCensus\Trace\Reporter\GoogleCloudReporter;
+ * use OpenCensus\Trace\Exporter\GoogleCloudExporter;
  *
- * $reporter = new GoogleCloudReporter([
+ * $reporter = new GoogleCloudExporter([
  *   'clientConfig' => [
  *      'projectId' => 'my-project'
  *   ]
@@ -48,9 +48,9 @@ use OpenCensus\Trace\TraceSpan as OpenCensusTraceSpan;
  * Example:
  * ```
  * use OpenCensus\Trace\RequestTracer;
- * use OpenCensus\Trace\Reporter\GoogleCloudReporter;
+ * use OpenCensus\Trace\Exporter\GoogleCloudExporter;
  *
- * $reporter = new GoogleCloudReporter([
+ * $reporter = new GoogleCloudExporter([
  *   'async' => true,
  *   'clientConfig' => [
  *      'projectId' => 'my-project'
@@ -67,7 +67,7 @@ use OpenCensus\Trace\TraceSpan as OpenCensusTraceSpan;
  *      incompatible ways. Please use with caution, and test thoroughly when
  *      upgrading.
  */
-class GoogleCloudReporter implements ReporterInterface
+class GoogleCloudExporter implements ExporterInterface
 {
     const VERSION = '0.1.0';
 
@@ -108,7 +108,7 @@ class GoogleCloudReporter implements ReporterInterface
     private $async;
 
     /**
-     * Create a TraceReporter that utilizes background batching.
+     * Create a TraceExporter that utilizes background batching.
      *
      * @param array $options [optional] {
      *     Configuration options.

--- a/src/Trace/Exporter/LoggerExporter.php
+++ b/src/Trace/Exporter/LoggerExporter.php
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Trace\Reporter;
+namespace OpenCensus\Trace\Exporter;
 
 use OpenCensus\Trace\Tracer\TracerInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * This implementation of the ReporterInterface appends a json
+ * This implementation of the ExporterInterface appends a json
  * representation of the trace to a file.
  */
-class LoggerReporter implements ReporterInterface
+class LoggerExporter implements ExporterInterface
 {
     const DEFAULT_LOG_LEVEL = 'notice';
 
@@ -39,7 +39,7 @@ class LoggerReporter implements ReporterInterface
     private $level;
 
     /**
-     * Create a new LoggerReporter
+     * Create a new LoggerExporter
      *
      * @param LoggerInterface $logger The logger to write to.
      * @param string $level The logger level to write as. **Defaults to** `notice`.

--- a/src/Trace/Exporter/NullExporter.php
+++ b/src/Trace/Exporter/NullExporter.php
@@ -15,25 +15,23 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Trace\Reporter;
+namespace OpenCensus\Trace\Exporter;
 
 use OpenCensus\Trace\Tracer\TracerInterface;
 
 /**
- * This implementation of the ReporterInterface uses `print_r` to output
- * the trace's representation to stdout.
+ * This implementation of the ExporterInterface does nothing.
  */
-class EchoReporter implements ReporterInterface
+class NullExporter implements ExporterInterface
 {
     /**
-     * Report the provided Trace to a backend.
+     * Does nothing.
      *
      * @param  TracerInterface $tracer
      * @return bool
      */
     public function report(TracerInterface $tracer)
     {
-        print_r($tracer->spans());
         return true;
     }
 }

--- a/src/Trace/Exporter/ZipkinExporter.php
+++ b/src/Trace/Exporter/ZipkinExporter.php
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Trace\Reporter;
+namespace OpenCensus\Trace\Exporter;
 
 use OpenCensus\Trace\Tracer\TracerInterface;
 use OpenCensus\Trace\TraceSpan;
 
 /**
- * This implementation of the ReporterInterface appends a json
+ * This implementation of the ExporterInterface appends a json
  * representation of the trace to a file.
  */
-class ZipkinReporter implements ReporterInterface
+class ZipkinExporter implements ExporterInterface
 {
     /**
      * @var string
@@ -47,7 +47,7 @@ class ZipkinReporter implements ReporterInterface
     private $url;
 
     /**
-     * Create a new ZipkinReporter
+     * Create a new ZipkinExporter
      *
      * @param string $name The name of this application
      * @param string $host The hostname of the Zipkin server

--- a/src/Trace/RequestHandler.php
+++ b/src/Trace/RequestHandler.php
@@ -17,7 +17,7 @@
 
 namespace OpenCensus\Trace;
 
-use OpenCensus\Trace\Reporter\ReporterInterface;
+use OpenCensus\Trace\Exporter\ExporterInterface;
 use OpenCensus\Trace\Sampler\SamplerInterface;
 use OpenCensus\Trace\TraceSpan;
 use OpenCensus\Trace\Tracer\ContextTracer;
@@ -38,7 +38,7 @@ class RequestHandler
     const DEFAULT_ROOT_SPAN_NAME = 'main';
 
     /**
-     * @var ReporterInterface The reported to use at the end of the request
+     * @var ExporterInterface The reported to use at the end of the request
      */
     private $reporter;
 
@@ -50,7 +50,7 @@ class RequestHandler
     /**
      * Create a new RequestHandler.
      *
-     * @param ReporterInterface $reporter How to report the trace at the end of the request
+     * @param ExporterInterface $reporter How to report the trace at the end of the request
      * @param SamplerInterface $sampler Which sampler to use for sampling requests
      * @param PropagatorInterface $propagator TraceContext propagator
      * @param array $options [optional] {
@@ -61,7 +61,7 @@ class RequestHandler
      * }
      */
     public function __construct(
-        ReporterInterface $reporter,
+        ExporterInterface $reporter,
         SamplerInterface $sampler,
         PropagatorInterface $propagator,
         array $options = []
@@ -104,7 +104,7 @@ class RequestHandler
 
     /**
      * The function registered as the shutdown function. Cleans up the trace and
-     * reports using the provided ReporterInterface. Adds additional labels to
+     * reports using the provided ExporterInterface. Adds additional labels to
      * the root span detected from the response.
      */
     public function onExit()

--- a/src/Trace/RequestTracer.php
+++ b/src/Trace/RequestTracer.php
@@ -19,7 +19,7 @@ namespace OpenCensus\Trace;
 
 use OpenCensus\Trace\Sampler\SamplerFactory;
 use OpenCensus\Trace\Sampler\SamplerInterface;
-use OpenCensus\Trace\Reporter\ReporterInterface;
+use OpenCensus\Trace\Exporter\ExporterInterface;
 use OpenCensus\Trace\Propagator\PropagatorInterface;
 use OpenCensus\Trace\Propagator\HttpHeaderPropagator;
 
@@ -33,9 +33,9 @@ use OpenCensus\Trace\Propagator\HttpHeaderPropagator;
  * Example:
  * ```
  * use OpenCensus\Trace\RequestTracer;
- * use OpenCensus\Trace\Reporter\EchoReporter;
+ * use OpenCensus\Trace\Exporter\EchoExporter;
  *
- * $reporter = new EchoReporter();
+ * $reporter = new EchoExporter();
  * RequestTracer::start($reporter);
  * ```
  *
@@ -110,7 +110,7 @@ class RequestTracer
      * Start a new trace session for this request. You should call this as early as
      * possible for the most accurate results.
      *
-     * @param ReporterInterface $reporter
+     * @param ExporterInterface $reporter
      * @param array $options {
      *      Configuration options. See
      *      {@see OpenCensus\Trace\TraceSpan::__construct()} for the other available options.
@@ -123,7 +123,7 @@ class RequestTracer
      * }
      * @return RequestHandler
      */
-    public static function start(ReporterInterface $reporter, array $options = [])
+    public static function start(ExporterInterface $reporter, array $options = [])
     {
         $samplerOptions = array_key_exists('sampler', $options) ? $options['sampler'] : [];
         unset($options['sampler']);

--- a/src/Trace/Sampler/AlwaysSampleSampler.php
+++ b/src/Trace/Sampler/AlwaysSampleSampler.php
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,30 +15,21 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Tests\Unit\Trace\Sampler;
-
-use OpenCensus\Trace\Sampler\RandomSampler;
+namespace OpenCensus\Trace\Sampler;
 
 /**
- * @group trace
+ * This implementation of the SamplerInterface always returns false. Use this
+ * sampler to attempt to trace all requests. You may be throttled by the server.
  */
-class RandomSamplerTest extends \PHPUnit_Framework_TestCase
+class AlwaysSampleSampler implements SamplerInterface
 {
     /**
-     * @dataProvider invalidRates
-     * @expectedException \InvalidArgumentException
+     * Returns true because we always want to sample.
+     *
+     * @return bool
      */
-    public function testInvalidRate($rate)
+    public function shouldSample()
     {
-        $sampler = new RandomSampler($rate);
-    }
-
-    public function invalidRates()
-    {
-        return [
-            [-1],
-            [10],
-            [1.1]
-        ];
+        return true;
     }
 }

--- a/src/Trace/Sampler/NeverSampleSampler.php
+++ b/src/Trace/Sampler/NeverSampleSampler.php
@@ -21,7 +21,7 @@ namespace OpenCensus\Trace\Sampler;
  * This implementation of the SamplerInterface always returns false. Use this
  * sampler to disable all tracing.
  */
-class AlwaysOffSampler implements SamplerInterface
+class NeverSampleSampler implements SamplerInterface
 {
     /**
      * Returns false because we never want to sample.

--- a/src/Trace/Sampler/ProbabilitySampler.php
+++ b/src/Trace/Sampler/ProbabilitySampler.php
@@ -21,7 +21,7 @@ namespace OpenCensus\Trace\Sampler;
  * This implementation of the SamplerInterface uses a pseudo-random number generator
  * to sample a percentage of requests.
  */
-class RandomSampler implements SamplerInterface
+class ProbabilitySampler implements SamplerInterface
 {
     /**
      * @var float The percentage of requests to sample represented as a float between 0 and 1.
@@ -29,7 +29,7 @@ class RandomSampler implements SamplerInterface
     private $rate;
 
     /**
-     * Creates the RandomSampler
+     * Creates the ProbabilitySampler
      *
      * @param float $percentage The percentage of requests to sample. Must be between 0 and 1.
      */

--- a/src/Trace/Sampler/SamplerFactory.php
+++ b/src/Trace/Sampler/SamplerFactory.php
@@ -60,12 +60,12 @@ class SamplerFactory
                     $options
                 );
             case 'random':
-                return new RandomSampler($options['rate']);
+                return new ProbabilitySampler($options['rate']);
             case 'enabled':
-                return new AlwaysOnSampler();
+                return new AlwaysSampleSampler();
             case 'disabled':
             default:
-                return new AlwaysOffSampler();
+                return new NeverSampleSampler();
         }
     }
 }

--- a/tests/unit/Trace/Exporter/EchoExporterTest.php
+++ b/tests/unit/Trace/Exporter/EchoExporterTest.php
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Tests\Unit\Trace\Reporter;
+namespace OpenCensus\Tests\Unit\Trace\Exporter;
 
-use OpenCensus\Trace\Reporter\EchoReporter;
+use OpenCensus\Trace\Exporter\EchoExporter;
 use OpenCensus\Trace\TraceContext;
 use OpenCensus\Trace\TraceSpan;
 use OpenCensus\Trace\Tracer\TracerInterface;
@@ -25,7 +25,7 @@ use OpenCensus\Trace\Tracer\TracerInterface;
 /**
  * @group trace
  */
-class EchoReporterTest extends \PHPUnit_Framework_TestCase
+class EchoExporterTest extends \PHPUnit_Framework_TestCase
 {
     private $tracer;
 
@@ -47,7 +47,7 @@ class EchoReporterTest extends \PHPUnit_Framework_TestCase
         $this->tracer->spans()->willReturn($spans);
 
         ob_start();
-        $reporter = new EchoReporter();
+        $reporter = new EchoExporter();
         $this->assertTrue($reporter->report($this->tracer->reveal()));
         $output = ob_get_contents();
         ob_end_clean();

--- a/tests/unit/Trace/Exporter/FileExporterTest.php
+++ b/tests/unit/Trace/Exporter/FileExporterTest.php
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Tests\Unit\Trace\Reporter;
+namespace OpenCensus\Tests\Unit\Trace\Exporter;
 
-use OpenCensus\Trace\Reporter\FileReporter;
+use OpenCensus\Trace\Exporter\FileExporter;
 use OpenCensus\Trace\TraceContext;
 use OpenCensus\Trace\TraceSpan;
 use OpenCensus\Trace\Tracer\TracerInterface;
@@ -25,7 +25,7 @@ use OpenCensus\Trace\Tracer\TracerInterface;
 /**
  * @group trace
  */
-class FileReporterTest extends \PHPUnit_Framework_TestCase
+class FileExporterTest extends \PHPUnit_Framework_TestCase
 {
     private $tracer;
     private $filename;
@@ -53,7 +53,7 @@ class FileReporterTest extends \PHPUnit_Framework_TestCase
         $this->tracer->context()->willReturn(new TraceContext('testtraceid'));
         $this->tracer->spans()->willReturn($spans);
 
-        $reporter = new FileReporter($this->filename);
+        $reporter = new FileExporter($this->filename);
         $this->assertTrue($reporter->report($this->tracer->reveal()));
         $this->assertGreaterThan(0, strlen(@file_get_contents($this->filename)));
     }

--- a/tests/unit/Trace/Exporter/GoogleCloudExporterTest.php
+++ b/tests/unit/Trace/Exporter/GoogleCloudExporterTest.php
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Tests\Unit\Trace\Reporter;
+namespace OpenCensus\Tests\Unit\Trace\Exporter;
 
 require_once __DIR__ . '/mock_error_log.php';
 
-use OpenCensus\Trace\Reporter\GoogleCloudReporter;
+use OpenCensus\Trace\Exporter\GoogleCloudExporter;
 use OpenCensus\Trace\TraceContext;
 use OpenCensus\Trace\Tracer\TracerInterface;
 use OpenCensus\Trace\Tracer\ContextTracer;
@@ -32,7 +32,7 @@ use Google\Cloud\Trace\TraceClient;
 /**
  * @group trace
  */
-class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
+class GoogleCloudExporterTest extends \PHPUnit_Framework_TestCase
 {
     private $client;
 
@@ -50,7 +50,7 @@ class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
             $tracer->inSpan(['name' => 'span2'], 'usleep', [20]);
         });
 
-        $reporter = new GoogleCloudReporter(['client' => $this->client->reveal()]);
+        $reporter = new GoogleCloudExporter(['client' => $this->client->reveal()]);
         $spans = $reporter->convertSpans($tracer);
 
         $this->assertCount(3, $spans);
@@ -73,7 +73,7 @@ class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
         $trace = $this->prophesize(Trace::class);
         $trace->setSpans(Argument::any())->shouldBeCalled();
         $this->client->trace(Argument::any())->willReturn($trace->reveal());
-        $reporter = new GoogleCloudReporter(
+        $reporter = new GoogleCloudExporter(
             ['client' => $this->client->reveal()]
         );
         $this->expectOutputString(
@@ -92,7 +92,7 @@ class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
             $tracer->inSpan(['name' => 'span4', 'kind' => OpenCensusTraceSpan::SPAN_KIND_CONSUMER], 'usleep', [1]);
         });
 
-        $reporter = new GoogleCloudReporter(['client' => $this->client->reveal()]);
+        $reporter = new GoogleCloudExporter(['client' => $this->client->reveal()]);
         $spans = $reporter->convertSpans($tracer);
 
         $this->assertCount(5, $spans);
@@ -111,7 +111,7 @@ class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer(new TraceContext('testtraceid'));
         $tracer->inSpan(['name' => 'main'], function () {});
 
-        $reporter = new GoogleCloudReporter(['client' => $this->client->reveal()]);
+        $reporter = new GoogleCloudExporter(['client' => $this->client->reveal()]);
         $reporter->processSpans($tracer, [$headerKey => $headerValue]);
         $spans = $tracer->spans();
         $labels = $spans[0]->labels();
@@ -149,7 +149,7 @@ class GoogleCloudReporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer(new TraceContext('testtraceid'));
         $tracer->inSpan(['backtrace' => $backtrace], function () {});
 
-        $reporter = new GoogleCloudReporter(['client' => $this->client->reveal()]);
+        $reporter = new GoogleCloudExporter(['client' => $this->client->reveal()]);
         $spans = $reporter->convertSpans($tracer);
 
         $labels = $spans[0]->info()['labels'];

--- a/tests/unit/Trace/Exporter/LoggerExporterTest.php
+++ b/tests/unit/Trace/Exporter/LoggerExporterTest.php
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Tests\Unit\Trace\Reporter;
+namespace OpenCensus\Tests\Unit\Trace\Exporter;
 
 require_once __DIR__ . '/mock_error_log.php';
 
 use Psr\Log\LoggerInterface;
-use OpenCensus\Trace\Reporter\LoggerReporter;
+use OpenCensus\Trace\Exporter\LoggerExporter;
 use OpenCensus\Trace\TraceContext;
 use OpenCensus\Trace\TraceSpan;
 use OpenCensus\Trace\Tracer\TracerInterface;
@@ -29,7 +29,7 @@ use Prophecy\Argument;
 /**
  * @group trace
  */
-class LoggerReporterTest extends \PHPUnit_Framework_TestCase
+class LoggerExporterTest extends \PHPUnit_Framework_TestCase
 {
     private $tracer;
     private $logger;
@@ -55,7 +55,7 @@ class LoggerReporterTest extends \PHPUnit_Framework_TestCase
             new \Exception('error_log test')
         );
 
-        $reporter = new LoggerReporter($this->logger->reveal(), 'some-level');
+        $reporter = new LoggerExporter($this->logger->reveal(), 'some-level');
         $this->expectOutputString(
             'Reporting the Trace data failed: error_log test'
         );
@@ -76,7 +76,7 @@ class LoggerReporterTest extends \PHPUnit_Framework_TestCase
 
         $this->logger->log('some-level', Argument::type('string'))->shouldBeCalled();
 
-        $reporter = new LoggerReporter($this->logger->reveal(), 'some-level');
+        $reporter = new LoggerExporter($this->logger->reveal(), 'some-level');
         $this->assertTrue($reporter->report($this->tracer->reveal()));
     }
 }

--- a/tests/unit/Trace/Exporter/ZipkinReporterTest.php
+++ b/tests/unit/Trace/Exporter/ZipkinReporterTest.php
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Tests\Unit\Trace\Reporter;
+namespace OpenCensus\Tests\Unit\Trace\Exporter;
 
-use OpenCensus\Trace\Reporter\ZipkinReporter;
+use OpenCensus\Trace\Exporter\ZipkinExporter;
 use OpenCensus\Trace\TraceContext;
 use OpenCensus\Trace\TraceSpan;
 use OpenCensus\Trace\Tracer\TracerInterface;
@@ -27,7 +27,7 @@ use Prophecy\Argument;
 /**
  * @group trace
  */
-class ZipkinReporterTest extends \PHPUnit_Framework_TestCase
+class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
 {
     private $tracer;
 
@@ -51,7 +51,7 @@ class ZipkinReporterTest extends \PHPUnit_Framework_TestCase
         $this->tracer->context()->willReturn(new TraceContext());
         $this->tracer->spans()->willReturn($spans);
 
-        $reporter = new ZipkinReporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
 
         $data = $reporter->convertSpans($this->tracer->reveal());
 
@@ -83,7 +83,7 @@ class ZipkinReporterTest extends \PHPUnit_Framework_TestCase
             $tracer->inSpan(['name' => 'span4', 'kind' => TraceSpan::SPAN_KIND_CONSUMER], 'usleep', [1]);
         });
 
-        $reporter = new ZipkinReporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
         $spans = $reporter->convertSpans($tracer);
 
         $annotationValue = function ($annotation) {
@@ -103,7 +103,7 @@ class ZipkinReporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer(new TraceContext('testtraceid'));
         $tracer->inSpan(['name' => 'main'], function () {});
 
-        $reporter = new ZipkinReporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
         $spans = $reporter->convertSpans($tracer, [
             'HTTP_X_B3_FLAGS' => '1'
         ]);
@@ -117,7 +117,7 @@ class ZipkinReporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer(new TraceContext('testtraceid', 12345));
         $tracer->inSpan(['name' => 'main'], function () {});
 
-        $reporter = new ZipkinReporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
         $spans = $reporter->convertSpans($tracer);
 
         $this->assertCount(1, $spans);

--- a/tests/unit/Trace/Exporter/mock_error_log.php
+++ b/tests/unit/Trace/Exporter/mock_error_log.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Trace\Reporter;
+namespace OpenCensus\Trace\Exporter;
 
 /**
  * A mock function for testing error_log function.

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -19,7 +19,7 @@ namespace OpenCensus\Tests\Unit\Trace;
 
 use OpenCensus\Trace\TraceSpan;
 use OpenCensus\Trace\RequestHandler;
-use OpenCensus\Trace\Reporter\ReporterInterface;
+use OpenCensus\Trace\Exporter\ExporterInterface;
 use OpenCensus\Trace\Sampler\SamplerInterface;
 use OpenCensus\Trace\Tracer\NullTracer;
 use OpenCensus\Trace\Propagator\HttpHeaderPropagator;
@@ -38,7 +38,7 @@ class RequestHandlerTest extends \PHPUnit_Framework_TestCase
         if (extension_loaded('stackdriver')) {
             stackdriver_trace_clear();
         }
-        $this->reporter = $this->prophesize(ReporterInterface::class);
+        $this->reporter = $this->prophesize(ExporterInterface::class);
         $this->sampler = $this->prophesize(SamplerInterface::class);
     }
 

--- a/tests/unit/Trace/RequestTracerTest.php
+++ b/tests/unit/Trace/RequestTracerTest.php
@@ -17,7 +17,7 @@
 
 namespace OpenCensus\Tests\Unit\Trace;
 
-use OpenCensus\Trace\Reporter\ReporterInterface;
+use OpenCensus\Trace\Exporter\ExporterInterface;
 use OpenCensus\Trace\RequestTracer;
 use OpenCensus\Trace\Tracer\NullTracer;
 
@@ -30,7 +30,7 @@ class RequestTracerTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->reporter = $this->prophesize(ReporterInterface::class);
+        $this->reporter = $this->prophesize(ExporterInterface::class);
     }
 
     public function testForceDisabled()

--- a/tests/unit/Trace/Sampler/ProbabilitySamplerTest.php
+++ b/tests/unit/Trace/Sampler/ProbabilitySamplerTest.php
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,21 +15,30 @@
  * limitations under the License.
  */
 
-namespace OpenCensus\Trace\Sampler;
+namespace OpenCensus\Tests\Unit\Trace\Sampler;
+
+use OpenCensus\Trace\Sampler\ProbabilitySampler;
 
 /**
- * This implementation of the SamplerInterface always returns false. Use this
- * sampler to attempt to trace all requests. You may be throttled by the server.
+ * @group trace
  */
-class AlwaysOnSampler implements SamplerInterface
+class ProbabilitySamplerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Returns true because we always want to sample.
-     *
-     * @return bool
+     * @dataProvider invalidRates
+     * @expectedException \InvalidArgumentException
      */
-    public function shouldSample()
+    public function testInvalidRate($rate)
     {
-        return true;
+        $sampler = new ProbabilitySampler($rate);
+    }
+
+    public function invalidRates()
+    {
+        return [
+            [-1],
+            [10],
+            [1.1]
+        ];
     }
 }

--- a/tests/unit/Trace/Sampler/SamplerFactoryTest.php
+++ b/tests/unit/Trace/Sampler/SamplerFactoryTest.php
@@ -19,9 +19,9 @@ namespace OpenCensus\Tests\Unit\Trace\Sampler;
 
 use OpenCensus\Trace\Sampler\SamplerFactory;
 use OpenCensus\Trace\Sampler\SamplerInterface;
-use OpenCensus\Trace\Sampler\AlwaysOnSampler;
+use OpenCensus\Trace\Sampler\AlwaysSampleSampler;
 use OpenCensus\Trace\Sampler\QpsSampler;
-use OpenCensus\Trace\Sampler\RandomSampler;
+use OpenCensus\Trace\Sampler\ProbabilitySampler;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -34,7 +34,7 @@ class SamplerFactoryTest extends \PHPUnit_Framework_TestCase
         $sampler = SamplerFactory::build([]);
 
         $this->assertTrue($sampler->shouldSample());
-        $this->assertInstanceOf(AlwaysOnSampler::class, $sampler);
+        $this->assertInstanceOf(AlwaysSampleSampler::class, $sampler);
     }
 
     public function testBuildQps()
@@ -78,7 +78,7 @@ class SamplerFactoryTest extends \PHPUnit_Framework_TestCase
             'type' => 'random',
             'rate' => 0.2
         ]);
-        $this->assertInstanceOf(RandomSampler::class, $sampler);
+        $this->assertInstanceOf(ProbabilitySampler::class, $sampler);
         $this->assertEquals(0.2, $sampler->rate());
     }
 
@@ -87,7 +87,7 @@ class SamplerFactoryTest extends \PHPUnit_Framework_TestCase
         $sampler = SamplerFactory::build([
             'type' => 'random'
         ]);
-        $this->assertInstanceOf(RandomSampler::class, $sampler);
+        $this->assertInstanceOf(ProbabilitySampler::class, $sampler);
         $this->assertEquals(0.1, $sampler->rate());
     }
 


### PR DESCRIPTION
Fixes #39 

* Renames samplers to match [naming convention](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Sampling.md)
* Renames `Reporter` to `Exporter` to match terminology in [OpenCensus spec](https://github.com/census-instrumentation/opencensus-specs/blob/master/README.md#service-exporters)