### PR TITLE
Prepare 0.0.4 packagist opencensus/opencensus release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
         "twig/twig": "~2.0",
         "symfony/yaml": "~3.3"
     },
+    "conflict": {
+        "ext-opencensus": "> 0.0.4"
+    },
     "suggest": {
         "ext-opencensus": "Enable tracing arbitrary functions.",
         "cache/apcu-adapter": "Enable QpsSampler to use apcu cache.",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/yaml": "~3.3"
     },
     "conflict": {
-        "ext-opencensus": "> 0.0.4"
+        "ext-opencensus": ">= 0.1.0"
     },
     "suggest": {
         "ext-opencensus": "Enable tracing arbitrary functions.",


### PR DESCRIPTION
Add a composer conflict for >= 0.1.0 version of the opencensus extension.
Since the extension is a soft dependency, we can't add a section to the `require`. Instead, we can specify that this package conflicts with a higher version of the opencensus extension.