### PR TITLE
Data model

### DIFF
--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -273,7 +273,7 @@ static opencensus_trace_span_t *opencensus_trace_begin(zend_string *function_nam
 {
     opencensus_trace_span_t *span = opencensus_trace_span_alloc();
 
-    zend_fetch_debug_backtrace(&span->backtrace, 1, DEBUG_BACKTRACE_IGNORE_ARGS, 0);
+    zend_fetch_debug_backtrace(&span->stackTrace, 1, DEBUG_BACKTRACE_IGNORE_ARGS, 0);
 
     span->start = opencensus_now();
     span->name = zend_string_copy(function_name);
@@ -628,7 +628,7 @@ PHP_FUNCTION(opencensus_trace_list)
         ZVAL_ARR(&attribute, trace_span->attributes);
         zend_update_property(opencensus_trace_span_ce, &span, "attributes", sizeof("attributes") - 1, &attribute);
 
-        zend_update_property(opencensus_trace_span_ce, &span, "backtrace", sizeof("backtrace") - 1, &trace_span->backtrace);
+        zend_update_property(opencensus_trace_span_ce, &span, "stackTrace", sizeof("stackTrace") - 1, &trace_span->stackTrace);
 
         add_next_index_zval(return_value, &span);
     } ZEND_HASH_FOREACH_END();

--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -210,18 +210,18 @@ static PHP_METHOD(OpenCensusTraceSpan, endTime) {
 }
 
 /**
- * Fetch the backtrace from the moment the span was started
+ * Fetch the stackTrace from the moment the span was started
  *
  * @return array
  */
-static PHP_METHOD(OpenCensusTraceSpan, backtrace) {
+static PHP_METHOD(OpenCensusTraceSpan, stackTrace) {
     zval *val, rv;
 
     if (zend_parse_parameters_none() == FAILURE) {
         return;
     }
 
-    val = zend_read_property(opencensus_trace_span_ce, getThis(), "backtrace", sizeof("backtrace") - 1, 1, &rv);
+    val = zend_read_property(opencensus_trace_span_ce, getThis(), "stackTrace", sizeof("stackTrace") - 1, 1, &rv);
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -252,7 +252,7 @@ static zend_function_entry opencensus_trace_span_methods[] = {
     PHP_ME(OpenCensusTraceSpan, attributes, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(OpenCensusTraceSpan, startTime, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(OpenCensusTraceSpan, endTime, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(OpenCensusTraceSpan, backtrace, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(OpenCensusTraceSpan, stackTrace, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(OpenCensusTraceSpan, kind, NULL, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };
@@ -275,7 +275,7 @@ int opencensus_trace_span_minit(INIT_FUNC_ARGS) {
     zend_declare_property_null(opencensus_trace_span_ce, "endTime", sizeof("endTime") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
     zend_declare_property_null(opencensus_trace_span_ce, "kind", sizeof("kind") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
     zend_declare_property_null(opencensus_trace_span_ce, "attributes", sizeof("attributes") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
-    zend_declare_property_null(opencensus_trace_span_ce, "backtrace", sizeof("backtrace") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
+    zend_declare_property_null(opencensus_trace_span_ce, "stackTrace", sizeof("stackTrace") - 1, ZEND_ACC_PROTECTED TSRMLS_CC);
 
     REGISTER_TRACE_SPAN_CONSTANT(KIND_UNKNOWN);
     REGISTER_TRACE_SPAN_CONSTANT(KIND_CLIENT);

--- a/ext/opencensus_trace_span.h
+++ b/ext/opencensus_trace_span.h
@@ -34,7 +34,7 @@ typedef struct opencensus_trace_span_t {
     double start;
     double stop;
     struct opencensus_trace_span_t *parent;
-    zval backtrace;
+    zval stackTrace;
     zend_long kind;
 
     // zend_string* => zval*

--- a/ext/tests/backtrace_test.phpt
+++ b/ext/tests/backtrace_test.phpt
@@ -20,7 +20,7 @@ $traces = opencensus_trace_list();
 echo "Number of traces: " . count($traces) . "\n";
 
 foreach ($traces as $span) {
-    var_dump($span->backtrace());
+    var_dump($span->stackTrace());
 }
 ?>
 --EXPECTF--

--- a/ext/tests/manual_spans_default_options.phpt
+++ b/ext/tests/manual_spans_default_options.phpt
@@ -33,7 +33,7 @@ Array
                 (
                 )
 
-            [backtrace:protected] => Array
+            [stackTrace:protected] => Array
                 (
                 )
 
@@ -51,7 +51,7 @@ Array
                 (
                 )
 
-            [backtrace:protected] => Array
+            [stackTrace:protected] => Array
                 (
                 )
 

--- a/src/Trace/Exporter/StackdriverExporter.php
+++ b/src/Trace/Exporter/StackdriverExporter.php
@@ -218,10 +218,10 @@ class StackdriverExporter implements ExporterInterface
         }, $tracer->spans());
     }
 
-    private function formatBacktrace($bt)
+    private function formatBacktrace($st)
     {
         return json_encode([
-            'stack_frame' => array_map([$this, 'mapStackframe'], $bt)
+            'stack_frame' => array_map([$this, 'mapStackframe'], $st)
         ]);
     }
 

--- a/src/Trace/Exporter/StackdriverExporter.php
+++ b/src/Trace/Exporter/StackdriverExporter.php
@@ -213,7 +213,7 @@ class StackdriverExporter implements ExporterInterface
                 ? $spanKindMap[$span->kind()]
                 :  TraceSpan::SPAN_KIND_UNSPECIFIED;
             $attributes = $span->attributes();
-            $attributes[self::STACKTRACE] = $this->formatBacktrace($span->backtrace());
+            $attributes[self::STACKTRACE] = $this->formatBacktrace($span->stackTrace());
             return new TraceSpan([
                 'name' => $span->name(),
                 'startTime' => $span->startTime(),

--- a/src/Trace/Exporter/StackdriverExporter.php
+++ b/src/Trace/Exporter/StackdriverExporter.php
@@ -263,18 +263,6 @@ class StackdriverExporter implements ExporterInterface
     {
         $headers = $headers ?: $_SERVER;
 
-        // If a redirect, add the HTTP_REDIRECTED_URL attribute to the main span
-        $responseCode = http_response_code();
-        if ($responseCode == 301 || $responseCode == 302) {
-            foreach (headers_list() as $header) {
-                if (substr($header, 0, 9) == 'Location:') {
-                    $tracer->addRootAttribute(self::HTTP_REDIRECTED_URL, substr($header, 10));
-                    break;
-                }
-            }
-        }
-        $tracer->addRootAttribute(self::HTTP_STATUS_CODE, $responseCode);
-
         $attributeMap = [
             self::HTTP_URL => ['REQUEST_URI'],
             self::HTTP_METHOD => ['REQUEST_METHOD'],

--- a/src/Trace/Exporter/StackdriverExporter.php
+++ b/src/Trace/Exporter/StackdriverExporter.php
@@ -202,16 +202,8 @@ class StackdriverExporter implements ExporterInterface
      */
     public function convertSpans(TracerInterface $tracer)
     {
-        $spanKindMap = [
-            Span::SPAN_KIND_CLIENT => TraceSpan::SPAN_KIND_RPC_CLIENT,
-            Span::SPAN_KIND_SERVER => TraceSpan::SPAN_KIND_RPC_SERVER
-        ];
-
         // transform OpenCensus Spans to Google\Cloud\Spans
-        return array_map(function ($span) use ($spanKindMap) {
-            $kind = array_key_exists($span->kind(), $spanKindMap)
-                ? $spanKindMap[$span->kind()]
-                :  TraceSpan::SPAN_KIND_UNSPECIFIED;
+        return array_map(function ($span) {
             $attributes = $span->attributes();
             $attributes[self::STACKTRACE] = $this->formatBacktrace($span->stackTrace());
             return new TraceSpan([
@@ -220,8 +212,7 @@ class StackdriverExporter implements ExporterInterface
                 'endTime' => $span->endTime(),
                 'spanId' => hexdec($span->spanId()),
                 'parentSpanId' => $span->parentSpanId() ? hexdec($span->parentSpanId()) : null,
-                'labels' => $attributes,
-                'kind' => $kind,
+                'labels' => $attributes
             ]);
             $span->info();
         }, $tracer->spans());

--- a/src/Trace/Exporter/ZipkinExporter.php
+++ b/src/Trace/Exporter/ZipkinExporter.php
@@ -109,13 +109,6 @@ class ZipkinExporter implements ExporterInterface
         $rootSpan = $spans[0];
         $traceId = $tracer->spanContext()->traceId();
 
-        $kindMap = [
-            Span::SPAN_KIND_CLIENT => 'CLIENT',
-            Span::SPAN_KIND_SERVER => 'SERVER',
-            Span::SPAN_KIND_PRODUCER => 'PRODUCER',
-            Span::SPAN_KIND_CONSUMER => 'CONSUMER'
-        ];
-
         // True is a request to store this span even if it overrides sampling policy.
         // This is true when the X-B3-Flags header has a value of 1.
         $isDebug = array_key_exists('HTTP_X_B3_FLAGS', $headers) && $headers['HTTP_X_B3_FLAGS'] == '1';
@@ -150,9 +143,6 @@ class ZipkinExporter implements ExporterInterface
                 'localEndpoint' => $localEndpoint,
                 'tags' => $span->attributes()
             ];
-            if (array_key_exists($span->kind(), $kindMap)) {
-                $zipkinSpan['kind'] = $kindMap[$span->kind()];
-            }
 
             $zipkinSpans[] = $zipkinSpan;
         }

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -168,6 +168,10 @@ class Span
             $this->parentSpanId = $options['parentSpanId'];
         }
 
+        if (array_key_exists('status', $options)) {
+            $this->status = $options['status'];
+        }
+
         if (array_key_exists('sameProcessAsParentSpan', $options)) {
             $this->sameProcessAsParentSpan = $options['sameProcessAsParentSpan'];
         }
@@ -255,6 +259,17 @@ class Span
     public function attributes()
     {
         return $this->attributes;
+    }
+
+    /**
+     * Set the status for this span.
+     *
+     * @param int $code The status code
+     * @param string $message A developer-facing error message
+     */
+    public function setStatus($code, $message)
+    {
+        $this->status = new Status($code, $message);
     }
 
     /**

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -369,8 +369,8 @@ class Span
     private function filterStackTrace($stackTrace)
     {
         return array_values(
-            array_filter($stackTrace, function ($bt) {
-                return !array_key_exists('class', $bt) || substr($bt['class'], 0, 16) != 'OpenCensus\Trace';
+            array_filter($stackTrace, function ($st) {
+                return !array_key_exists('class', $st) || substr($st['class'], 0, 16) != 'OpenCensus\Trace';
             })
         );
     }
@@ -384,12 +384,12 @@ class Span
     private function generateSpanName()
     {
         // Try to find the first stacktrace class entry that doesn't start with OpenCensus\Trace
-        foreach ($this->stackTrace() as $bt) {
-            $bt += ['line' => null];
-            if (!array_key_exists('class', $bt)) {
-                return implode('/', array_filter(['app', basename($bt['file']), $bt['function'], $bt['line']]));
-            } elseif (substr($bt['class'], 0, 18) != 'OpenCensus\Trace') {
-                return implode('/', array_filter(['app', $bt['class'], $bt['function'], $bt['line']]));
+        foreach ($this->stackTrace() as $st) {
+            $st += ['line' => null];
+            if (!array_key_exists('class', $st)) {
+                return implode('/', array_filter(['app', basename($st['file']), $st['function'], $st['line']]));
+            } elseif (substr($st['class'], 0, 18) != 'OpenCensus\Trace') {
+                return implode('/', array_filter(['app', $st['class'], $st['function'], $st['line']]));
             }
         }
 

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -27,15 +27,89 @@ namespace OpenCensus\Trace;
 class Span
 {
     /**
-     * @var array Associative array containing all the fields representing this Span.
+     * Unique identifier for a trace. All spans from the same Trace share the
+     * same `traceId`. 16-byte value encoded as a hex string.
+     *
+     * @var string
      */
-    private $info = [];
+    private $traceId;
 
-    const SPAN_KIND_UNKNOWN = 0;
-    const SPAN_KIND_CLIENT = 1;
-    const SPAN_KIND_SERVER = 2;
-    const SPAN_KIND_PRODUCER = 3;
-    const SPAN_KIND_CONSUMER = 4;
+    /**
+     * Unique identifier for a span within a trace, assigned when the span is
+     * created. 8-byte value encoded as a hex string.
+     *
+     * @var string
+     */
+    private $spanId;
+
+    /**
+     * The `spanId` of this span's parent span. If this is a root span, then
+     * this field must be empty. 8-byte value encoded as a hex string.
+     *
+     * @var string
+     */
+    private $parentSpanId;
+
+    /**
+     * A description of the span's operation.
+     *
+     * For example, the name can be a qualified method name or a file name
+     * and a line number where the operation is called. A best practice is to
+     * use the same display name within an application and at the same call
+     * point. This makes it easier to correlate spans in different traces.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The start time of the span. On the client side, this is the time kept by
+     * the local machine where the span execution starts. On the server side,
+     * this is the time when the server's application handler starts running.
+     *
+     * @var \DateTimeInterface
+     */
+    private $startTime;
+
+    /**
+     * The end time of the span. On the client side, this is the time kept by
+     * the local machine where the span execution ends. On the server side, this
+     * is the time when the server application handler stops running.
+     *
+     * @var \DateTimeInterface
+     */
+    private $endTime;
+
+    /**
+     * A set of attributes on the span. An associative array of string => mixed
+     *
+     * @var array
+     */
+    private $attributes;
+
+    /**
+     * Stack trace captured at the start of the span. This is in the format of
+     * `debug_backtrace`.
+     *
+     * @var array
+     */
+    private $stackTrace;
+
+    /**
+     * An optional final status for this span.
+     *
+     * @var Status
+     */
+    private $status;
+
+    /**
+     * A highly recommended but not required flag that identifies when a trace
+     * crosses a process boundary. True when the parent_span belongs to the
+     * same process as the current span.
+     *
+     * @var bool
+     */
+    private $sameProcessAsParentSpan;
 
     /**
      * Instantiate a new Span instance.
@@ -61,52 +135,42 @@ class Span
     {
         if (array_key_exists('startTime', $options)) {
             $this->setStartTime($options['startTime']);
-            unset($options['startTime']);
-        }
-        if (array_key_exists('endTime', $options)) {
-            $this->setEndTime($options['endTime']);
-            unset($options['endTime']);
         }
 
+        if (array_key_exists('endTime', $options)) {
+            $this->setEndTime($options['endTime']);
+        }
+
+        $this->attributes = [];
         if (array_key_exists('attributes', $options)) {
             $this->addAttributes($options['attributes']);
-            unset($options['attributes']);
         }
 
         if (array_key_exists('spanId', $options)) {
-            $this->info['spanId'] = $options['spanId'];
-            unset($options['spanId']);
+            $this->spanId = $options['spanId'];
         } else {
-            $this->info['spanId'] = $this->generateSpanId();
+            $this->spanId = $this->generateSpanId();
         }
 
-        if (array_key_exists('backtrace', $options)) {
-            $this->info['backtrace'] = $this->filterBacktrace($options['backtrace']);
-            unset($options['backtrace']);
+        if (array_key_exists('stackTrace', $options)) {
+            $this->stackTrace = $this->filterStackTrace($options['stackTrace']);
         } else {
-            $this->info['backtrace'] = $this->filterBacktrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
-        }
-
-        if (array_key_exists('kind', $options)) {
-            $this->info['kind'] = $options['kind'];
-            unset($options['kind']);
-        } else {
-            $this->info['kind'] = self::SPAN_KIND_UNKNOWN;
+            $this->stackTrace = $this->filterStackTrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
         }
 
         if (array_key_exists('name', $options)) {
-            $this->info['name'] = $options['name'];
-            unset($options['name']);
+            $this->name = $options['name'];
         } else {
-            $this->info['name'] = $this->generateSpanName();
+            $this->name = $this->generateSpanName();
         }
 
         if (array_key_exists('parentSpanId', $options)) {
-            $this->info['parentSpanId'] = $options['parentSpanId'];
-            unset($options['parentSpanId']);
+            $this->parentSpanId = $options['parentSpanId'];
         }
 
-        $this->info['metadata'] = $options;
+        if (array_key_exists('sameProcessAsParentSpan', $options)) {
+            $this->sameProcessAsParentSpan = $options['sameProcessAsParentSpan'];
+        }
     }
 
     /**
@@ -116,18 +180,19 @@ class Span
      */
     public function startTime()
     {
-        return $this->info['startTime'];
+        return $this->startTime;
     }
 
     /**
      * Set the start time for this span.
      *
-     * @param  \DateTimeInterface|int|float $when [optional] The start time of this span.
-     *         **Defaults to** now. If provided as an int or float, it is expected to be a Unix timestamp.
+     * @param  \DateTimeInterface|int|float $when [optional] The start time of
+     *         this span. **Defaults to** now. If provided as an int or float,
+     *         it is expected to be a Unix timestamp.
      */
     public function setStartTime($when = null)
     {
-        $this->info['startTime'] = $this->formatDate($when);
+        $this->startTime = $this->formatDate($when);
     }
 
     /**
@@ -137,18 +202,19 @@ class Span
      */
     public function endTime()
     {
-        return $this->info['endTime'];
+        return $this->endTime;
     }
 
     /**
      * Set the end time for this span.
      *
-     * @param  \DateTimeInterface|int|float $when [optional] The end time of this span.
-     *         **Defaults to** now. If provided as an int or float, it is expected to be a Unix timestamp.
+     * @param  \DateTimeInterface|int|float $when [optional] The end time of
+     *         this span. **Defaults to** now. If provided as an int or float,
+     *         it is expected to be a Unix timestamp.
      */
     public function setEndTime($when = null)
     {
-        $this->info['endTime'] = $this->formatDate($when);
+        $this->endTime = $this->formatDate($when);
     }
 
     /**
@@ -158,7 +224,7 @@ class Span
      */
     public function spanId()
     {
-        return $this->info['spanId'];
+        return $this->spanId;
     }
 
     /**
@@ -168,9 +234,7 @@ class Span
      */
     public function parentSpanId()
     {
-        return array_key_exists('parentSpanId', $this->info)
-            ? $this->info['parentSpanId']
-            : null;
+        return $this->parentSpanId;
     }
 
     /**
@@ -180,7 +244,7 @@ class Span
      */
     public function name()
     {
-        return $this->info['name'];
+        return $this->name;
     }
 
     /**
@@ -190,39 +254,37 @@ class Span
      */
     public function attributes()
     {
-        return array_key_exists('attributes', $this->info)
-            ? $this->info['attributes']
-            : [];
+        return $this->attributes;
     }
 
     /**
-     * Retrieve the backtrace at the moment this span was created
+     * Retrieve the final status for this span.
+     *
+     * @return Status
+     */
+    public function status()
+    {
+        return $this->status;
+    }
+
+    /**
+     * Retrieve the stackTrace at the moment this span was created
      *
      * @return array
      */
-    public function backtrace()
+    public function stackTrace()
     {
-        return $this->info['backtrace'];
+        return $this->stackTrace;
     }
 
     /**
-     * Retrieve the kind of span
+     * Whether or not this span is in the same process as its parent.
      *
-     * @return int One of SPAN_KIND_UNKNOWN|SPAN_KIND_CLIENT|SPAN_KIND_SERVER|SPAN_KIND_CONSUMER|SPAN_KIND_PRODUCER
+     * @return bool
      */
-    public function kind()
+    public function sameProcessAsParentSpan()
     {
-        return $this->info['kind'];
-    }
-
-    /**
-     * Returns a serializable array representing this span.
-     *
-     * @return array
-     */
-    public function info()
-    {
-        return $this->info;
+        return $this->sameProcessAsParentSpan;
     }
 
     /**
@@ -245,10 +307,7 @@ class Span
      */
     public function addAttribute($attribute, $value)
     {
-        if (!array_key_exists('attributes', $this->info)) {
-            $this->info['attributes'] = [];
-        }
-        $this->info['attributes'][$attribute] = (string) $value;
+        $this->attributes[$attribute] = (string) $value;
     }
 
     /**
@@ -288,14 +347,14 @@ class Span
     }
 
     /**
-     * Return a filtered backtrace where we strip out all functions from the OpenCensus\Trace namespace
+     * Return a filtered stackTrace where we strip out all functions from the OpenCensus\Trace namespace
      *
      * @return array
      */
-    private function filterBacktrace($backtrace)
+    private function filterStackTrace($stackTrace)
     {
         return array_values(
-            array_filter($backtrace, function ($bt) {
+            array_filter($stackTrace, function ($bt) {
                 return !array_key_exists('class', $bt) || substr($bt['class'], 0, 16) != 'OpenCensus\Trace';
             })
         );
@@ -310,7 +369,7 @@ class Span
     private function generateSpanName()
     {
         // Try to find the first stacktrace class entry that doesn't start with OpenCensus\Trace
-        foreach ($this->backtrace() as $bt) {
+        foreach ($this->stackTrace() as $bt) {
             $bt += ['line' => null];
             if (!array_key_exists('class', $bt)) {
                 return implode('/', array_filter(['app', basename($bt['file']), $bt['function'], $bt['line']]));
@@ -319,7 +378,7 @@ class Span
             }
         }
 
-        // We couldn't find a suitable backtrace entry - generate a random one
+        // We couldn't find a suitable stackTrace entry - generate a random one
         return uniqid('span');
     }
 }

--- a/src/Trace/Status.php
+++ b/src/Trace/Status.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright 2017 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace;
+
+/**
+ * The `Status` type defines a logical error model that is suitable for
+ * different programming environments, including REST APIs and RPC APIs. It is
+ * used by [gRPC](https://github.com/grpc).
+ */
+class Status
+{
+    /**
+     * @var int The status code
+     */
+    private $code;
+
+    /**
+     * @var string A developer-facing error message, which should be in English
+     */
+    private $message;
+
+    /**
+     * Create a new Status object
+     *
+     * @param int $code The status code
+     * @param string $message A developer-facing error message
+     */
+    public function __construct($code, $message)
+    {
+        $this->code = $code;
+        $this->message = $message;
+    }
+
+    /**
+     * Returns the status code.
+     *
+     * @return int
+     */
+    public function code()
+    {
+        return $this->code;
+    }
+
+    /**
+     * Returns the developer-facing error message
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return $this->message;
+    }
+}

--- a/src/Trace/Tracer/ExtensionTracer.php
+++ b/src/Trace/Tracer/ExtensionTracer.php
@@ -78,7 +78,14 @@ class ExtensionTracer implements TracerInterface
      */
     public function withSpan(Span $span)
     {
-        opencensus_trace_begin($span->name(), $span->info());
+        $info = [
+            'spanId' => $span->spanId(),
+            'parentSpanId' => $span->parentSpanId(),
+            'startTime' => $span->startTime(),
+            'attributes' => $span->attributes(),
+            'stackTrace' => $span->stackTrace()
+        ];
+        opencensus_trace_begin($span->name(), $info);
         return new Scope(function () {
             opencensus_trace_finish();
         });
@@ -101,7 +108,7 @@ class ExtensionTracer implements TracerInterface
                 'startTime' => $span->startTime(),
                 'endTime' => $span->endTime(),
                 'attributes' => $span->attributes(),
-                'backtrace' => $span->backtrace()
+                'stackTrace' => $span->stackTrace()
             ]);
         }, opencensus_trace_list());
     }

--- a/tests/unit/Trace/Exporter/StackdriverExporterTest.php
+++ b/tests/unit/Trace/Exporter/StackdriverExporterTest.php
@@ -86,10 +86,10 @@ class StackdriverExporterTest extends \PHPUnit_Framework_TestCase
     {
         $tracer = new ContextTracer(new SpanContext('testtraceid'));
         $tracer->inSpan(['name' => 'main'], function () use ($tracer) {
-            $tracer->inSpan(['name' => 'span1', 'kind' => OpenCensusSpan::SPAN_KIND_CLIENT], 'usleep', [1]);
-            $tracer->inSpan(['name' => 'span2', 'kind' => OpenCensusSpan::SPAN_KIND_SERVER], 'usleep', [1]);
-            $tracer->inSpan(['name' => 'span3', 'kind' => OpenCensusSpan::SPAN_KIND_PRODUCER], 'usleep', [1]);
-            $tracer->inSpan(['name' => 'span4', 'kind' => OpenCensusSpan::SPAN_KIND_CONSUMER], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span1'], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span2'], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span3'], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span4'], 'usleep', [1]);
         });
 
         $reporter = new StackdriverExporter(['client' => $this->client->reveal()]);
@@ -97,10 +97,6 @@ class StackdriverExporterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(5, $spans);
         $this->assertEquals(TraceSpan::SPAN_KIND_UNSPECIFIED, $spans[0]->info()['kind']);
-        $this->assertEquals(TraceSpan::SPAN_KIND_RPC_CLIENT, $spans[1]->info()['kind']);
-        $this->assertEquals(TraceSpan::SPAN_KIND_RPC_SERVER, $spans[2]->info()['kind']);
-        $this->assertEquals(TraceSpan::SPAN_KIND_UNSPECIFIED, $spans[3]->info()['kind']);
-        $this->assertEquals(TraceSpan::SPAN_KIND_UNSPECIFIED, $spans[4]->info()['kind']);
     }
 
     /**

--- a/tests/unit/Trace/Exporter/StackdriverExporterTest.php
+++ b/tests/unit/Trace/Exporter/StackdriverExporterTest.php
@@ -137,7 +137,7 @@ class StackdriverExporterTest extends \PHPUnit_Framework_TestCase
 
     public function testStacktraceAttribute()
     {
-        $backtrace = [
+        $stackTrace = [
             [
                 'file' => '/path/to/file.php',
                 'class' => 'Foo',
@@ -147,7 +147,7 @@ class StackdriverExporterTest extends \PHPUnit_Framework_TestCase
             ]
         ];
         $tracer = new ContextTracer(new SpanContext('testtraceid'));
-        $tracer->inSpan(['backtrace' => $backtrace], function () {});
+        $tracer->inSpan(['stackTrace' => $stackTrace], function () {});
 
         $reporter = new StackdriverExporter(['client' => $this->client->reveal()]);
         $spans = $reporter->convertSpans($tracer);

--- a/tests/unit/Trace/Exporter/ZipkinExporterTest.php
+++ b/tests/unit/Trace/Exporter/ZipkinExporterTest.php
@@ -80,10 +80,10 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
     {
         $tracer = new ContextTracer(new SpanContext('testtraceid'));
         $tracer->inSpan(['name' => 'main'], function () use ($tracer) {
-            $tracer->inSpan(['name' => 'span1', 'kind' => Span::SPAN_KIND_CLIENT], 'usleep', [1]);
-            $tracer->inSpan(['name' => 'span2', 'kind' => Span::SPAN_KIND_SERVER], 'usleep', [1]);
-            $tracer->inSpan(['name' => 'span3', 'kind' => Span::SPAN_KIND_PRODUCER], 'usleep', [1]);
-            $tracer->inSpan(['name' => 'span4', 'kind' => Span::SPAN_KIND_CONSUMER], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span1'], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span2'], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span3'], 'usleep', [1]);
+            $tracer->inSpan(['name' => 'span4'], 'usleep', [1]);
         });
 
         $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
@@ -95,10 +95,6 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(5, $spans);
         $this->assertFalse(array_key_exists('kind', $spans[0]));
-        $this->assertEquals('CLIENT', $spans[1]['kind']);
-        $this->assertEquals('SERVER', $spans[2]['kind']);
-        $this->assertEquals('PRODUCER', $spans[3]['kind']);
-        $this->assertEquals('CONSUMER', $spans[4]['kind']);
     }
 
     public function testSpanDebug()

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -58,11 +58,11 @@ class RequestHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $spans);
         foreach ($spans as $span) {
             $this->assertInstanceOf(Span::class, $span);
-            $this->assertArrayHasKey('endTime', $span->info());
+            $this->assertNotEmpty($span->endTime());
         }
         $this->assertEquals('main', $spans[0]->name());
         $this->assertEquals('inner', $spans[1]->name());
-        $this->assertEquals($spans[0]->spanId(), $spans[1]->info()['parentSpanId']);
+        $this->assertEquals($spans[0]->spanId(), $spans[1]->parentSpanId());
     }
 
     public function testCanParseParentContext()
@@ -78,7 +78,7 @@ class RequestHandlerTest extends \PHPUnit_Framework_TestCase
             ]
         );
         $span = $rt->tracer()->spans()[0];
-        $this->assertEquals('15b3', $span->info()['parentSpanId']);
+        $this->assertEquals('15b3', $span->parentSpanId());
         $context = $rt->tracer()->spanContext();
         $this->assertEquals('12345678901234567890123456789012', $context->traceId());
     }

--- a/tests/unit/Trace/SpanTest.php
+++ b/tests/unit/Trace/SpanTest.php
@@ -28,121 +28,95 @@ class SpanTest extends \PHPUnit_Framework_TestCase
 
     public function testGeneratesDefaultSpanId()
     {
-        $traceSpan = new Span();
-        $info = $traceSpan->info();
-        $this->assertArrayHasKey('spanId', $info);
-        $this->assertEquals($info['spanId'], $traceSpan->spanId());
+        $span = new Span();
+
+        $this->assertNotEmpty($span->spanId());
     }
 
     public function testReadsSpanId()
     {
-        $traceSpan = new Span(['spanId' => '1234']);
-        $info = $traceSpan->info();
-        $this->assertArrayHasKey('spanId', $info);
-        $this->assertEquals('1234', $info['spanId']);
+        $span = new Span(['spanId' => '1234']);
+
+        $this->assertEquals('1234', $span->spanId());
     }
 
     public function testReadsAttributes()
     {
-        $traceSpan = new Span(['attributes' => ['foo' => 'bar']]);
-        $info = $traceSpan->info();
-        $this->assertArrayHasKey('attributes', $info);
-        $this->assertEquals('bar', $info['attributes']['foo']);
+        $span = new Span(['attributes' => ['foo' => 'bar']]);
+
+        $attributes = $span->attributes();
+        $this->assertArrayHasKey('foo', $attributes);
+        $this->assertEquals('bar', $attributes['foo']);
     }
 
     public function testCanAddAttribute()
     {
-        $traceSpan = new Span();
-        $traceSpan->addAttribute('foo', 'bar');
-        $info = $traceSpan->info();
-        $this->assertArrayHasKey('attributes', $info);
-        $this->assertEquals('bar', $info['attributes']['foo']);
+        $span = new Span();
+        $span->addAttribute('foo', 'bar');
+
+        $attributes = $span->attributes();
+        $this->assertArrayHasKey('foo', $attributes);
+        $this->assertEquals('bar', $attributes['foo']);
     }
 
     public function testNoAttributes()
     {
-        $traceSpan = new Span();
-        $info = $traceSpan->info();
-        $this->assertArrayNotHasKey('attributes', $info);
+        $span = new Span();
+
+        $this->assertEmpty($span->attributes());
     }
 
     public function testEmptyAttributes()
     {
-        $traceSpan = new Span(['attributes' => []]);
-        $info = $traceSpan->info();
-        $this->assertArrayNotHasKey('attributes', $info);
+        $span = new Span(['attributes' => []]);
+
+        $this->assertEquals([], $span->attributes());
     }
 
     public function testGeneratesDefaultSpanName()
     {
-        $traceSpan = new Span();
-        $info = $traceSpan->info();
-        $this->assertArrayHasKey('name', $info);
-        $this->assertStringStartsWith('app', $info['name']);
-        $this->assertEquals($info['name'], $traceSpan->name());
+        $span = new Span();
+
+        $this->assertStringStartsWith('app', $span->name());
     }
 
     public function testReadsName()
     {
-        $traceSpan = new Span(['name' => 'myspan']);
-        $info = $traceSpan->info();
-        $this->assertArrayHasKey('name', $info);
-        $this->assertEquals('myspan', $info['name']);
+        $span = new Span(['name' => 'myspan']);
+
+        $this->assertEquals('myspan', $span->name());
     }
 
     public function testStartFormat()
     {
-        $traceSpan = new Span();
-        $traceSpan->setStartTime();
-        $info = $traceSpan->info();
-        $this->assertArrayHasKey('startTime', $info);
-        $this->assertInstanceOf(\DateTimeInterface::class, $info['startTime']);
+        $span = new Span();
+        $span->setStartTime();
+
+        $this->assertInstanceOf(\DateTimeInterface::class, $span->startTime());
     }
 
     public function testFinishFormat()
     {
-        $traceSpan = new Span();
-        $traceSpan->setEndTime();
-        $info = $traceSpan->info();
-        $this->assertArrayHasKey('endTime', $info);
-        $this->assertInstanceOf(\DateTimeInterface::class, $info['endTime']);
-    }
+        $span = new Span();
+        $span->setEndTime();
 
-    public function testGeneratesDefaultKind()
-   {
-       $traceSpan = new Span();
-       $info = $traceSpan->info();
-       $this->assertArrayHasKey('kind', $info);
-       $this->assertEquals(Span::SPAN_KIND_UNKNOWN, $info['kind']);
-   }
-   public function testReadsKind()
-   {
-       $traceSpan = new Span(['kind' => Span::SPAN_KIND_CLIENT]);
-       $info = $traceSpan->info();
-       $this->assertArrayHasKey('kind', $info);
-       $this->assertEquals(Span::SPAN_KIND_CLIENT, $info['kind']);
-   }
-
-    public function testIgnoresUnknownFields()
-    {
-        $traceSpan = new Span(['extravalue' => 'something']);
-        $info = $traceSpan->info();
-        $this->assertArrayNotHasKey('extravalue', $info);
+        $this->assertInstanceOf(\DateTimeInterface::class, $span->endTime());
     }
 
     public function testGeneratesBacktrace()
     {
-        $traceSpan = new Span();
-        $this->assertInternalType('array', $traceSpan->backtrace());
-        $this->assertTrue(count($traceSpan->backtrace()) > 0);
-        $stackframe = $traceSpan->backtrace()[0];
+        $span = new Span();
+
+        $this->assertInternalType('array', $span->stackTrace());
+        $this->assertTrue(count($span->stackTrace()) > 0);
+        $stackframe = $span->stackTrace()[0];
         $this->assertEquals('testGeneratesBacktrace', $stackframe['function']);
         $this->assertEquals(self::class, $stackframe['class']);
     }
 
     public function testOverrideBacktrace()
     {
-        $backtrace = [
+        $stackTrace = [
             [
                 'class' => 'Foo',
                 'line' => 1234,
@@ -150,12 +124,12 @@ class SpanTest extends \PHPUnit_Framework_TestCase
                 'type' => '::'
             ]
         ];
-        $traceSpan = new Span([
-            'backtrace' => $backtrace
+        $span = new Span([
+            'stackTrace' => $stackTrace
         ]);
 
-        $this->assertCount(1, $traceSpan->backtrace());
-        $stackframe = $traceSpan->backtrace()[0];
+        $this->assertCount(1, $span->stackTrace());
+        $stackframe = $span->stackTrace()[0];
         $this->assertEquals('asdf', $stackframe['function']);
         $this->assertEquals('Foo', $stackframe['class']);
     }
@@ -165,8 +139,10 @@ class SpanTest extends \PHPUnit_Framework_TestCase
      */
     public function testCanFormatTimestamps($field, $timestamp, $expected)
     {
-        $traceSpan = new Span([$field => $timestamp]);
-        $this->assertEquals($expected, $traceSpan->info()[$field]->format('Y-m-d\TH:i:s.u000\Z'));
+        $span = new Span([$field => $timestamp]);
+        $date = call_user_func([$span, $field]);
+        $this->assertInstanceOf(\DateTimeInterface::class, $date);
+        $this->assertEquals($expected, $date->format('Y-m-d\TH:i:s.u000\Z'));
     }
 
     public function timestampFields()

--- a/tests/unit/Trace/SpanTest.php
+++ b/tests/unit/Trace/SpanTest.php
@@ -18,6 +18,7 @@
 namespace OpenCensus\Tests\Unit\Trace;
 
 use OpenCensus\Trace\Span;
+use OpenCensus\Trace\Status;
 
 /**
  * @group trace
@@ -132,6 +133,33 @@ class SpanTest extends \PHPUnit_Framework_TestCase
         $stackframe = $span->stackTrace()[0];
         $this->assertEquals('asdf', $stackframe['function']);
         $this->assertEquals('Foo', $stackframe['class']);
+    }
+
+    public function testDefaultStatus()
+    {
+        $span = new Span();
+
+        $this->assertNull($span->status());
+    }
+
+    public function testConstructingWithStatus()
+    {
+        $status = new Status(200, 'OK');
+        $span = new Span(['status' => $status]);
+
+        $this->assertInstanceOf(Status::class, $span->status());
+        $this->assertEquals($status, $span->status());
+    }
+
+    public function testSettingStatus()
+    {
+        $span = new Span();
+        $span->setStatus(500, 'A server error occurred');
+
+        $status = $span->status();
+        $this->assertInstanceOf(Status::class, $status);
+        $this->assertEquals(500, $status->code());
+        $this->assertEquals('A server error occurred', $status->message());
     }
 
     /**

--- a/tests/unit/Trace/Tracer/ContextTracerTest.php
+++ b/tests/unit/Trace/Tracer/ContextTracerTest.php
@@ -67,8 +67,9 @@ class ContextTracerTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $spans);
         $span = $spans[1];
         $this->assertEquals('inner', $span->name());
-        $info = $span->info();
-        $this->assertEquals('bar', $info['attributes']['foo']);
+        $attributes = $span->attributes();
+        $this->assertArrayHasKey('foo', $attributes);
+        $this->assertEquals('bar', $attributes['foo']);
     }
 
     public function testAddsAttributesToRootSpan()
@@ -84,8 +85,9 @@ class ContextTracerTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $spans);
         $span = $spans[0];
         $this->assertEquals('root', $span->name());
-        $info = $span->info();
-        $this->assertEquals('bar', $info['attributes']['foo']);
+        $attributes = $span->attributes();
+        $this->assertArrayHasKey('foo', $attributes);
+        $this->assertEquals('bar', $attributes['foo']);
     }
 
     public function testPersistsBacktrace()
@@ -93,7 +95,7 @@ class ContextTracerTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer();
         $tracer->inSpan(['name' => 'test'], function () {});
         $span = $tracer->spans()[0];
-        $stackframe = $span->backtrace()[0];
+        $stackframe = $span->stackTrace()[0];
         $this->assertEquals('testPersistsBacktrace', $stackframe['function']);
         $this->assertEquals(self::class, $stackframe['class']);
     }

--- a/tests/unit/Trace/Tracer/ExtentionTracerTest.php
+++ b/tests/unit/Trace/Tracer/ExtentionTracerTest.php
@@ -69,8 +69,9 @@ class ExtensionTracerTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $spans);
         $span = $spans[1];
         $this->assertEquals('inner', $span->name());
-        $info = $span->info();
-        $this->assertEquals('bar', $info['attributes']['foo']);
+        $attributes = $span->attributes();
+        $this->assertArrayHasKey('foo', $attributes);
+        $this->assertEquals('bar', $attributes['foo']);
     }
 
     public function testAddsAttributesToRootSpan()
@@ -86,8 +87,9 @@ class ExtensionTracerTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $spans);
         $span = $spans[0];
         $this->assertEquals('root', $span->name());
-        $info = $span->info();
-        $this->assertEquals('bar', $info['attributes']['foo']);
+        $attributes = $span->attributes();
+        $this->assertArrayHasKey('foo', $attributes);
+        $this->assertEquals('bar', $attributes['foo']);
     }
 
     public function testPersistsBacktrace()
@@ -95,7 +97,7 @@ class ExtensionTracerTest extends \PHPUnit_Framework_TestCase
         $tracer = new ExtensionTracer();
         $tracer->inSpan(['name' => 'test'], function () {});
         $span = $tracer->spans()[0];
-        $stackframe = $span->backtrace()[0];
+        $stackframe = $span->stackTrace()[0];
         $this->assertEquals('testPersistsBacktrace', $stackframe['function']);
         $this->assertEquals(self::class, $stackframe['class']);
     }


### PR DESCRIPTION
* Adds `Span->status()` - a `OpenCensus\Trace\Status` instance
* Removes `Span->kind()` - not a supported field type
* Adds `Span->sameProcessAsParentSpan()`
* Renames `Span->backtrace()` -> `Span->stackTrace()`

Fixes #38