### PR TITLE
Fix Travis documentation build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ install:
   - sudo dpkg -i /tmp/hugo.deb
 
 script:
-  - cd docs && hugo
+  - pushd docs
+  - hugo
+  - popd
   - php sami.phar update config/sami.php
   - touch docs/.nojekyll
 


### PR DESCRIPTION
the script commands do not reset the current working directory
ensure we return to the right directory

Failure: https://travis-ci.org/census-instrumentation/opencensus-php/builds/310176215