### PR TITLE
Fix the base url for the hugo site

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "http://opencensus.io/opencensus-php/"
 languageCode = "en-us"
 title = "OpenCensus for PHP"
 theme = "hyde"

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -7,10 +7,6 @@ menu:
     weight: -100
 ---
 
-# OpenCensus for PHP
-
-[API Documentation][api-docs]
-
 ## Installation
 
 1. Install the `opencensus/opencensus` package using [composer][composer]:

--- a/docs/content/using-the-extension.md
+++ b/docs/content/using-the-extension.md
@@ -16,7 +16,7 @@ calls in order to automatically collect nested spans (timing data).
 You can install the `opencensus` extension from [PECL](https://pecl.php.net):
 
 ```bash
-$ pecl instal opencensus-alpha
+$ pecl install opencensus-alpha
 ```
 
 Enable the extension in your `php.ini`:


### PR DESCRIPTION
The nav links were taking you to http://opencensus.io/<page name> instead of http://opencensus.io/opencensus-php/<page name>