### PR TITLE
Test library against released php 7.2

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
     waitFor: ['-']
     id: php70
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '--build-arg', 'BASE_IMAGE=gcr.io/php-mvm-a/php72:alpha3', '.']
+    args: ['build', '--build-arg', 'BASE_IMAGE=gcr.io/google-appengine/php72', '.']
     waitFor: ['-']
     id: php72
   - name: gcr.io/cloud-builders/docker

--- a/ext/README.md
+++ b/ext/README.md
@@ -20,7 +20,7 @@ This extension has been built and tested on the following PHP versions:
 
 * 7.0.x
 * 7.1.x
-* 7.2.0 (alpha3)
+* 7.2.x
 
 ## Installation
 


### PR DESCRIPTION
PHP 7.2 was officially released on 11/30. Test against the official 7.2.0 release rather than the alpha 3 version.