### PR TITLE
Fix windows build error on gettimeofday and other warnings

### DIFF
--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -19,19 +19,18 @@
 #include "opencensus_trace_span.h"
 #include "opencensus_trace_context.h"
 #include "opencensus_trace_annotation.h"
+#include "opencensus_trace_link.h"
+#include "opencensus_trace_message_event.h"
+#include "Zend/zend_builtin_functions.h"
 #include "Zend/zend_compile.h"
 #include "Zend/zend_closures.h"
+#include "Zend/zend_exceptions.h"
 #include "zend_extensions.h"
 #include "standard/php_math.h"
+#include "ext/standard/info.h"
 
 #if PHP_VERSION_ID < 70100
 #include "standard/php_rand.h"
-#endif
-
-#ifdef _WIN32
-#include "win32/time.h"
-#else
-#include <sys/time.h>
 #endif
 
 /**

--- a/ext/opencensus_trace_context.c
+++ b/ext/opencensus_trace_context.c
@@ -58,7 +58,6 @@ ZEND_END_ARG_INFO();
  */
 static PHP_METHOD(OpenCensusTraceContext, __construct) {
     zval *v;
-    ulong idx;
     zend_string *k;
     HashTable *context_options;
 
@@ -66,7 +65,7 @@ static PHP_METHOD(OpenCensusTraceContext, __construct) {
         return;
     }
 
-    ZEND_HASH_FOREACH_KEY_VAL(context_options, idx, k, v) {
+    ZEND_HASH_FOREACH_STR_KEY_VAL(context_options, k, v) {
         zend_update_property(opencensus_trace_context_ce, getThis(), ZSTR_VAL(k), strlen(ZSTR_VAL(k)), v);
     } ZEND_HASH_FOREACH_END();
 }

--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -503,6 +503,7 @@ static int opencensus_trace_update_time_events(opencensus_trace_span_t *span, zv
         opencensus_trace_time_event_to_zval(event, &zv);
         add_next_index_zval(return_value, &zv);
     } ZEND_HASH_FOREACH_END();
+	return SUCCESS;
 }
 
 static int opencensus_trace_update_links(opencensus_trace_span_t *span, zval *return_value)
@@ -513,6 +514,7 @@ static int opencensus_trace_update_links(opencensus_trace_span_t *span, zval *re
         opencensus_trace_link_to_zval(link, &zv);
         add_next_index_zval(return_value, &zv);
     } ZEND_HASH_FOREACH_END();
+	return SUCCESS;
 }
 
 /* Fill the provided span with the provided data from the internal span representation */

--- a/ext/php_opencensus.h
+++ b/ext/php_opencensus.h
@@ -24,6 +24,12 @@
 #include "php.h"
 #include "opencensus_trace.h"
 
+#ifdef _WIN32
+#include "win32/time.h"
+#else
+#include <sys/time.h>
+#endif
+
 #define PHP_OPENCENSUS_VERSION "0.0.4"
 #define PHP_OPENCENSUS_EXTNAME "opencensus"
 


### PR DESCRIPTION
From windows build log:
```
C:\php-snap-build\php-src\php70\x64\php-src\win32/time.h(45): error C2375: 'gettimeofday': redefinition; different linkage (compiling source file ext\opencensus\opencensus_trace.c)
```

Other warnings:
```
ext\opencensus\opencensus_trace.c(110): warning C4013: 'php_info_print_table_start' undefined; assuming extern returning int
ext\opencensus\opencensus_trace.c(111): warning C4013: 'php_info_print_table_row' undefined; assuming extern returning int
ext\opencensus\opencensus_trace.c(113): warning C4013: 'php_info_print_table_end' undefined; assuming extern returning int
ext\opencensus\opencensus_trace.c(339): warning C4013: 'zend_clear_exception' undefined; assuming extern returning int
ext\opencensus\opencensus_trace.c(403): warning C4013: 'zend_fetch_debug_backtrace' undefined; assuming extern returning int
ext\opencensus\opencensus_trace.c(790): warning C4013: 'opencensus_trace_link_minit' undefined; assuming extern returning int
ext\opencensus\opencensus_trace.c(791): warning C4013: 'opencensus_trace_message_event_minit' undefined; assuming extern returning int
c:\php-snap-build\php-src\php70\x64\php-src\ext\opencensus\opencensus_trace_span.c(516) : warning C4716: 'opencensus_trace_update_links': must return a value
c:\php-snap-build\php-src\php70\x64\php-src\ext\opencensus\opencensus_trace_span.c(506) : warning C4716: 'opencensus_trace_update_time_events': must return a value
```