### PR TITLE
Fix 'Bad metadata value given' for grpc integration

### DIFF
--- a/src/Trace/Integrations/Grpc.php
+++ b/src/Trace/Integrations/Grpc.php
@@ -116,7 +116,7 @@ class Grpc implements IntegrationInterface
         if ($context = Tracer::spanContext()) {
             $propagator = new GrpcMetadataPropagator();
             $metadata += [
-                $propagator->key() => $propagator->formatter()->serialize($context)
+                $propagator->key() => [$propagator->formatter()->serialize($context)]
             ];
         }
         return $metadata;


### PR DESCRIPTION
The metadata value is expected to be an array. Otherwise we receive an "Bad metadata value given" error from the grpc library.