### PR TITLE
Allow Tracer usage in code when there is no active tracer

### DIFF
--- a/src/Trace/Integrations/Grpc.php
+++ b/src/Trace/Integrations/Grpc.php
@@ -113,7 +113,8 @@ class Grpc implements IntegrationInterface
      */
     public static function updateMetadata($metadata, $jwtAuthUri)
     {
-        if ($context = Tracer::spanContext()) {
+        $context = Tracer::spanContext();
+        if ($context->enabled()) {
             $propagator = new GrpcMetadataPropagator();
             $metadata += [
                 $propagator->key() => [$propagator->formatter()->serialize($context)]

--- a/src/Trace/Integrations/Guzzle/EventSubscriber.php
+++ b/src/Trace/Integrations/Guzzle/EventSubscriber.php
@@ -85,7 +85,8 @@ class EventSubscriber implements SubscriberInterface
     public function onBefore(BeforeEvent $event)
     {
         $request = $event->getRequest();
-        if ($context = Tracer::spanContext()) {
+        $context = Tracer::spanContext();
+        if ($context->enabled()) {
             $request->setHeader($this->propagator->key(), $this->propagator->formatter()->serialize($context));
         }
         $span = Tracer::startSpan([

--- a/src/Trace/Integrations/Guzzle/Middleware.php
+++ b/src/Trace/Integrations/Guzzle/Middleware.php
@@ -67,7 +67,8 @@ class Middleware
     public function __invoke(callable $handler)
     {
         return function (RequestInterface $request, $options) use ($handler) {
-            if ($context = Tracer::spanContext()) {
+            $context = Tracer::spanContext();
+            if ($context->enabled()) {
                 $request = $request->withHeader(
                     $this->propagator->key(),
                     $this->propagator->formatter()->serialize($context)

--- a/src/Trace/Tracer.php
+++ b/src/Trace/Tracer.php
@@ -161,6 +161,9 @@ class Tracer
      */
     public static function inSpan(array $spanOptions, callable $callable, array $arguments = [])
     {
+        if (!isset(self::$instance)) {
+            return call_user_func_array($callable, $arguments);
+        }
         return self::$instance->inSpan($spanOptions, $callable, $arguments);
     }
 
@@ -186,6 +189,9 @@ class Tracer
      */
     public static function startSpan(array $spanOptions = [])
     {
+        if (!isset(self::$instance)) {
+            return new Span();
+        }
         return self::$instance->startSpan($spanOptions);
     }
 
@@ -195,8 +201,8 @@ class Tracer
      *
      * Example:
      * ```
-     * $span = RequestTracer::startSpan(['name' => 'expensive-operation']);
-     * $scope = RequestTracer::withSpan($span);
+     * $span = Tracer::startSpan(['name' => 'expensive-operation']);
+     * $scope = Tracer::withSpan($span);
      * try {
      *     // do something expensive
      * } finally {
@@ -209,6 +215,10 @@ class Tracer
      */
     public static function withSpan(Span $span)
     {
+        if (!isset(self::$instance)) {
+            return new Scope(function () {
+            });
+        }
         return self::$instance->withSpan($span);
     }
 
@@ -223,6 +233,9 @@ class Tracer
      */
     public static function addAttribute($attribute, $value, $options = [])
     {
+        if (!isset(self::$instance)) {
+            return;
+        }
         return self::$instance->addAttribute($attribute, $value, $options);
     }
 
@@ -233,6 +246,9 @@ class Tracer
      */
     public static function spanContext()
     {
+        if (!isset(self::$instance)) {
+            return new SpanContext(null, null, false);
+        }
         return self::$instance->tracer()->spanContext();
     }
 }


### PR DESCRIPTION
For the most part this makes a Tracer without an $instance act like it
has a NullTracer.

Fixes #116