### PR TITLE
Fix file exporter serialization

### DIFF
--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -88,7 +88,7 @@ class Span
      *
      * @var array
      */
-    private $stackTrace;
+    private $stackTrace = [];
 
     /**
      * A collection of `TimeEvent`s. A `TimeEvent` is a time-stamped annotation
@@ -97,15 +97,15 @@ class Span
      *
      * @var TimeEvent[]
      */
-    private $timeEvents;
+    private $timeEvents = [];
 
     /**
      * A collection of links, which are references from this span to a span
      * in the same or different trace.
      *
-     * @var Link
+     * @var Link[]
      */
-    private $links;
+    private $links = [];
 
     /**
      * An optional final status for this span.

--- a/tests/unit/Trace/Exporter/FileExporterTest.php
+++ b/tests/unit/Trace/Exporter/FileExporterTest.php
@@ -43,6 +43,8 @@ class FileExporterTest extends \PHPUnit_Framework_TestCase
 
     public function testLogsTrace()
     {
+        $this->tracer->spanContext()->willReturn(new SpanContext());
+
         $spans = [
             new Span([
                 'name' => 'span',


### PR DESCRIPTION
The `FileExporter` report method uses `json_encode` but pass an `OpenCensus\Trace\Span` array as arg.

As `OpenCensus\Trace\Span` does not implements `JsonSerializable` it isn't serealizable.

Convert spans into arrays solves the issue.