### PR TITLE
Fix base-url for docs to use github.io link

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://opencensus.io/opencensus-php/"
+baseURL = "https://census-instrumentation.github.io/opencensus-php/"
 languageCode = "en-us"
 title = "OpenCensus for PHP"
 theme = "hyde"


### PR DESCRIPTION
For now, we're hosting the generated API documentation off of GitHub as the new website will be hosted elsewhere. Fixes #126 