### PR TITLE
Fix OSX segfault in extension

### DIFF
--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -364,7 +364,6 @@ static void opencensus_trace_execute_callback(opencensus_trace_span_t *span, zen
             opencensus_trace_span_apply_span_options(span, &callback_result);
         }
         ZVAL_DESTRUCTOR(&callback_result);
-        zend_string_release(callback_name);
     } else if (Z_TYPE_P(span_options) == IS_ARRAY) {
         opencensus_trace_span_apply_span_options(span, span_options);
     }

--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -28,10 +28,7 @@
 #include "zend_extensions.h"
 #include "standard/php_math.h"
 #include "ext/standard/info.h"
-
-#if PHP_VERSION_ID < 70100
 #include "standard/php_rand.h"
-#endif
 
 /**
  * True globals for storing the original zend_execute_ex and

--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -143,11 +143,12 @@ static zend_string *span_id_from_options(HashTable *options)
         return NULL;
     }
 
-    if (val = zend_hash_str_find(options, "spanId", strlen("spanId"))) {
-        return Z_STR_P(val);
-    } else {
+    val = zend_hash_str_find(options, "spanId", strlen("spanId"));
+    if (val == NULL) {
         return NULL;
     }
+
+    return Z_STR_P(val);
 }
 
 static opencensus_trace_span_t *span_from_options(zval *options)
@@ -159,7 +160,8 @@ static opencensus_trace_span_t *span_from_options(zval *options)
         return NULL;
     }
 
-    if (span_id = span_id_from_options(Z_ARR_P(options))) {
+    span_id = span_id_from_options(Z_ARR_P(options));
+    if (span_id != NULL) {
         span = (opencensus_trace_span_t *)zend_hash_find_ptr(OPENCENSUS_TRACE_G(spans), span_id);
     }
 

--- a/ext/opencensus_trace_annotation.c
+++ b/ext/opencensus_trace_annotation.c
@@ -44,6 +44,7 @@
 
 #include "php_opencensus.h"
 #include "opencensus_trace_annotation.h"
+#include "Zend/zend_alloc.h"
 
 zend_class_entry* opencensus_trace_annotation_ce = NULL;
 

--- a/ext/opencensus_trace_link.c
+++ b/ext/opencensus_trace_link.c
@@ -44,6 +44,7 @@
 
 #include "php_opencensus.h"
 #include "opencensus_trace_link.h"
+#include "Zend/zend_alloc.h"
 
 zend_class_entry* opencensus_trace_link_ce = NULL;
 

--- a/ext/opencensus_trace_message_event.c
+++ b/ext/opencensus_trace_message_event.c
@@ -50,6 +50,7 @@
 
 #include "php_opencensus.h"
 #include "opencensus_trace_message_event.h"
+#include "Zend/zend_alloc.h"
 
 zend_class_entry* opencensus_trace_message_event_ce = NULL;
 

--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -90,6 +90,7 @@
 #include "opencensus_trace_annotation.h"
 #include "opencensus_trace_link.h"
 #include "opencensus_trace_message_event.h"
+#include "Zend/zend_alloc.h"
 
 zend_class_entry* opencensus_trace_span_ce = NULL;
 

--- a/ext/php_opencensus.h
+++ b/ext/php_opencensus.h
@@ -33,10 +33,6 @@
 #define PHP_OPENCENSUS_VERSION "0.1.2"
 #define PHP_OPENCENSUS_EXTNAME "opencensus"
 
-#define PHP_OPENCENSUS_MAKE_STD_ZVAL(pzv) \
-  pzv = (zval *)emalloc(sizeof(zval));
-#define PHP_OPENCENSUS_FREE_STD_ZVAL(pzv) efree(pzv);
-
 PHP_FUNCTION(opencensus_version);
 
 extern zend_module_entry opencensus_module_entry;


### PR DESCRIPTION
Fix #129 

Removes a double `zend_string_release`.
Also cleans up some compiler warnings for OSX's clang