### PR TITLE
[#125] Adds support for zipkin span.kind tag.

### DIFF
--- a/src/Trace/Exporter/ZipkinExporter.php
+++ b/src/Trace/Exporter/ZipkinExporter.php
@@ -207,7 +207,7 @@ class ZipkinExporter implements ExporterInterface
             return self::KIND_SERVER;
         }
 
-        if ($span->timeEvents())) {
+        if ($span->timeEvents()) {
             foreach ($span->timeEvents() as $event) {
                 if (!($event instanceof MessageEvent)) {
                     continue;

--- a/src/Trace/Exporter/ZipkinExporter.php
+++ b/src/Trace/Exporter/ZipkinExporter.php
@@ -207,7 +207,7 @@ class ZipkinExporter implements ExporterInterface
             return self::KIND_SERVER;
         }
 
-        if (count($span->timeEvents()) > 0) {
+        if ($span->timeEvents())) {
             foreach ($span->timeEvents() as $event) {
                 if (!($event instanceof MessageEvent)) {
                     continue;


### PR DESCRIPTION
Based on https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/trace/zipkin/src/main/java/io/opencensus/exporter/trace/zipkin/ZipkinExporterHandler.java#L169 and https://github.com/census-instrumentation/opencensus-go/blob/master/exporter/zipkin/zipkin.go#L104 we port the same functionality to obtain the `span.kind` for span.

Ping @chingor13 