### PR TITLE
[#125] Simplifies the Zipkin exporter construction.

### DIFF
--- a/src/Trace/Exporter/ZipkinExporter.php
+++ b/src/Trace/Exporter/ZipkinExporter.php
@@ -30,7 +30,7 @@ use OpenCensus\Trace\Span;
  * use OpenCensus\Trace\Exporter\ZipkinExporter;
  * use OpenCensus\Trace\Tracer;
  *
- * $exporter = new ZipkinExporter('my_app', 'localhost', 9411);
+ * $exporter = new ZipkinExporter('my_app');
  * Tracer::begin($exporter);
  * ```
  */
@@ -38,21 +38,12 @@ class ZipkinExporter implements ExporterInterface
 {
     const KIND_SERVER = 'SERVER';
     const KIND_CLIENT = 'CLIENT';
+    const DEFAULT_ENDPOINT = 'http://localhost:9411/api/v2/spans';
 
     /**
      * @var string
      */
-    private $host;
-
-    /**
-     * @var int
-     */
-    private $port;
-
-    /**
-     * @var string
-     */
-    private $url;
+    private $endpointUrl;
 
     /**
      * @var array
@@ -63,19 +54,15 @@ class ZipkinExporter implements ExporterInterface
      * Create a new ZipkinExporter
      *
      * @param string $name The name of this application
-     * @param string $host The hostname of the Zipkin server
-     * @param int $port The port of the Zipkin server
-     * @param string $endpoint (optional) The path for the span reporting
-     *        endpoint. **Defaults to** `/api/v2/spans`
-     * @param array $server (optoinal) The server array to search for the
+     * @param string $endpointUrl (optional) The url for the span reporting
+     *        endpoint. **Defaults to** `http://localhost:9411/api/v2/spans`
+     * @param array $server (optional) The server array to search for the
      *        SERVER_PORT. **Defaults to** $_SERVER
      */
-    public function __construct($name, $host, $port, $endpoint = '/api/v2/spans', $server = null)
+    public function __construct($name, $endpointUrl = null, array $server = null)
     {
         $server = $server ?: $_SERVER;
-        $this->host = $host;
-        $this->port = $port;
-        $this->url = "http://${host}:${port}${endpoint}";
+        $this->endpointUrl = ($endpointUrl === null) ? self::DEFAULT_ENDPOINT : $endpointUrl;
         $this->localEndpoint = [
             'serviceName' => $name
         ];
@@ -131,7 +118,7 @@ class ZipkinExporter implements ExporterInterface
             ];
 
             $context = stream_context_create($contextOptions);
-            file_get_contents($this->url, false, $context);
+            file_get_contents($this->endpointUrl, false, $context);
         } catch (\Exception $e) {
             return false;
         }

--- a/tests/unit/Trace/Exporter/ZipkinExporterTest.php
+++ b/tests/unit/Trace/Exporter/ZipkinExporterTest.php
@@ -55,7 +55,7 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
         $this->tracer->spanContext()->willReturn(new SpanContext());
         $this->tracer->spans()->willReturn($spans);
 
-        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp');
 
         $data = $reporter->convertSpans($this->tracer->reveal());
 
@@ -90,7 +90,7 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
             $tracer->inSpan($spanOpts, 'usleep', [1]);
         });
 
-        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp');
         $spans = $reporter->convertSpans($tracer);
 
         $this->assertCount(2, $spans);
@@ -114,7 +114,7 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer($spanContext);
         $tracer->inSpan(['name' => 'main'], function () {});
 
-        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp');
         $spans = $reporter->convertSpans($tracer, [
             'HTTP_X_B3_FLAGS' => '1'
         ]);
@@ -129,7 +129,7 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer($spanContext);
         $tracer->inSpan(['name' => 'main'], function () {});
 
-        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp');
         $spans = $reporter->convertSpans($tracer);
 
         $this->assertCount(1, $spans);
@@ -140,7 +140,7 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
     {
         $spanContext = new SpanContext('testtraceid', 12345);
         $tracer = new ContextTracer($spanContext);
-        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp');
         $spans = $reporter->convertSpans($tracer);
         $this->assertEmpty($spans);
     }
@@ -151,7 +151,7 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer($spanContext);
         $tracer->inSpan(['name' => 'main'], function () {});
 
-        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp');
         $spans = $reporter->convertSpans($tracer);
         $endpoint = $spans[0]['localEndpoint'];
         $this->assertArrayNotHasKey('ipv4', $endpoint);
@@ -164,7 +164,7 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer($spanContext);
         $tracer->inSpan(['name' => 'main'], function () {});
 
-        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp');
         $reporter->setLocalIpv4('1.2.3.4');
         $spans = $reporter->convertSpans($tracer);
         $endpoint = $spans[0]['localEndpoint'];
@@ -178,7 +178,7 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer($spanContext);
         $tracer->inSpan(['name' => 'main'], function () {});
 
-        $reporter = new ZipkinExporter('myapp', 'localhost', 9411);
+        $reporter = new ZipkinExporter('myapp');
         $reporter->setLocalIpv6('2001:db8:85a3::8a2e:370:7334');
         $spans = $reporter->convertSpans($tracer);
         $endpoint = $spans[0]['localEndpoint'];
@@ -192,7 +192,7 @@ class ZipkinExporterTest extends \PHPUnit_Framework_TestCase
         $tracer = new ContextTracer($spanContext);
         $tracer->inSpan(['name' => 'main'], function () {});
 
-        $reporter = new ZipkinExporter('myapp', 'localhost', 9411, '/api/v2/spans', ['SERVER_PORT' => "80"]);
+        $reporter = new ZipkinExporter('myapp', null, ['SERVER_PORT' => "80"]);
         $spans = $reporter->convertSpans($tracer);
         $endpoint = $spans[0]['localEndpoint'];
         $this->assertArrayHasKey('port', $endpoint);


### PR DESCRIPTION
This PR simplifies the constructor for the zipkin exporter as the usual practice is to receive the `endpoint url` instead of `host`, `server` or `endpoint`.

Ping @chingor13 

Relates to #125