### PR TITLE
Extension spans should always return arrays

### DIFF
--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -192,6 +192,10 @@ static PHP_METHOD(OpenCensusTraceSpan, attributes) {
     }
 
     val = zend_read_property(opencensus_trace_span_ce, getThis(), "attributes", sizeof("attributes") - 1, 1, &rv);
+    if (ZVAL_IS_NULL(val)) {
+        array_init(return_value);
+        return;
+    }
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -209,6 +213,10 @@ static PHP_METHOD(OpenCensusTraceSpan, links) {
     }
 
     val = zend_read_property(opencensus_trace_span_ce, getThis(), "links", sizeof("links") - 1, 1, &rv);
+    if (ZVAL_IS_NULL(val)) {
+        array_init(return_value);
+        return;
+    }
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -226,6 +234,10 @@ static PHP_METHOD(OpenCensusTraceSpan, timeEvents) {
     }
 
     val = zend_read_property(opencensus_trace_span_ce, getThis(), "timeEvents", sizeof("timeEvents") - 1, 1, &rv);
+    if (ZVAL_IS_NULL(val)) {
+        array_init(return_value);
+        return;
+    }
 
     RETURN_ZVAL(val, 1, 0);
 }
@@ -277,6 +289,10 @@ static PHP_METHOD(OpenCensusTraceSpan, stackTrace) {
     }
 
     val = zend_read_property(opencensus_trace_span_ce, getThis(), "stackTrace", sizeof("stackTrace") - 1, 1, &rv);
+    if (ZVAL_IS_NULL(val)) {
+        array_init(return_value);
+        return;
+    }
 
     RETURN_ZVAL(val, 1, 0);
 }

--- a/ext/tests/span_class.phpt
+++ b/ext/tests/span_class.phpt
@@ -20,6 +20,13 @@ echo "Span startTime: {$span->startTime()}\n";
 
 echo "Span endTime: {$span->endTime()}\n";
 
+var_dump(gettype($span->attributes()));
+
+var_dump(gettype($span->stackTrace()));
+
+var_dump(gettype($span->links()));
+
+var_dump(gettype($span->timeEvents()));
 
 ?>
 --EXPECT--
@@ -27,3 +34,7 @@ Span id: 1234
 Span name: foo
 Span startTime: 12345.1
 Span endTime: 23456.2
+string(5) "array"
+string(5) "array"
+string(5) "array"
+string(5) "array"

--- a/tests/unit/Trace/Tracer/AbstractTracerTest.php
+++ b/tests/unit/Trace/Tracer/AbstractTracerTest.php
@@ -258,8 +258,72 @@ abstract class AbstractTracerTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals(0, $span->startTime()->getTimestamp());
     }
 
+    public function testStackTraceShouldBeSet()
+    {
+        $class = $this->getTracerClass();
+        $tracer = new $class();
+        $tracer->inSpan(['name' => 'foo'], function () {
+            // do nothing
+        });
+
+        $spans = $tracer->spans();
+        $this->assertCount(1, $spans);
+        $span = $spans[0];
+
+        $this->assertInternalType('array', $span->stackTrace());
+        $this->assertNotEmpty($span->stackTrace());
+    }
+
+    public function testAttributesShouldBeSet()
+    {
+        $class = $this->getTracerClass();
+        $tracer = new $class();
+        $tracer->inSpan(['name' => 'foo'], function () {
+            // do nothing
+        });
+
+        $spans = $tracer->spans();
+        $this->assertCount(1, $spans);
+        $span = $spans[0];
+
+        $this->assertInternalType('array', $span->attributes());
+        $this->assertEmpty($span->attributes());
+    }
+
+    public function testLinksShouldBeSet()
+    {
+        $class = $this->getTracerClass();
+        $tracer = new $class();
+        $tracer->inSpan(['name' => 'foo'], function () {
+            // do nothing
+        });
+
+        $spans = $tracer->spans();
+        $this->assertCount(1, $spans);
+        $span = $spans[0];
+
+        $this->assertInternalType('array', $span->links());
+        $this->assertEmpty($span->links());
+    }
+
+    public function testTimeEventsShouldBeSet()
+    {
+        $class = $this->getTracerClass();
+        $tracer = new $class();
+        $tracer->inSpan(['name' => 'foo'], function () {
+            // do nothing
+        });
+
+        $spans = $tracer->spans();
+        $this->assertCount(1, $spans);
+        $span = $spans[0];
+
+        $this->assertInternalType('array', $span->timeEvents());
+        $this->assertEmpty($span->timeEvents());
+    }
+
     private function assertEquivalentTimestamps($expected, $value)
     {
-        $this->assertEquals((float)($expected->format('U.u')), (float)($expected->format('U.u')), '', 0.000001);
+        $this->assertEquals((float)($expected->format('U.u')), (float)($value->format('U.u')), '', 0.000001);
     }
 }


### PR DESCRIPTION
Related to https://github.com/census-instrumentation/opencensus-php/pull/138#issuecomment-373464392