### PR TITLE
Fix ExporterInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "cache/adapter-common": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">= 4.8",
+        "phpunit/phpunit": ">= 6.0",
         "squizlabs/php_codesniffer": "2.*",
         "google/cloud-trace": "^0.4",
         "twig/twig": "~2.0",

--- a/src/Trace/Exporter/EchoExporter.php
+++ b/src/Trace/Exporter/EchoExporter.php
@@ -37,7 +37,7 @@ class EchoExporter implements ExporterInterface
     /**
      * Report the provided Trace to a backend.
      *
-     * @param  TracerInterface $tracer
+     * @param SpanData[] $spans
      * @return bool
      */
     public function export(array $spans)

--- a/src/Trace/Exporter/EchoExporter.php
+++ b/src/Trace/Exporter/EchoExporter.php
@@ -17,7 +17,7 @@
 
 namespace OpenCensus\Trace\Exporter;
 
-use OpenCensus\Trace\Tracer\TracerInterface;
+use OpenCensus\Trace\SpanData;
 
 /**
  * This implementation of the ExporterInterface uses `print_r` to output
@@ -40,9 +40,9 @@ class EchoExporter implements ExporterInterface
      * @param  TracerInterface $tracer
      * @return bool
      */
-    public function report(TracerInterface $tracer)
+    public function export(array $spans)
     {
-        print_r($tracer->spans());
+        print_r($spans);
         return true;
     }
 }

--- a/src/Trace/Exporter/ExporterInterface.php
+++ b/src/Trace/Exporter/ExporterInterface.php
@@ -17,7 +17,7 @@
 
 namespace OpenCensus\Trace\Exporter;
 
-use OpenCensus\Trace\Tracer\TracerInterface;
+use OpenCensus\Trace\SpanData;
 
 /**
  * The ExporterInterface allows you to swap out the Trace reporting mechanism
@@ -25,10 +25,10 @@ use OpenCensus\Trace\Tracer\TracerInterface;
 interface ExporterInterface
 {
     /**
-     * Report the provided Trace to a backend.
+     * Export the provided SpanData to a backend.
      *
-     * @param  TracerInterface $tracer
+     * @param SpanData[] $spans
      * @return bool
      */
-    public function report(TracerInterface $tracer);
+    public function export(array $spans);
 }

--- a/src/Trace/Exporter/FileExporter.php
+++ b/src/Trace/Exporter/FileExporter.php
@@ -17,7 +17,7 @@
 
 namespace OpenCensus\Trace\Exporter;
 
-use OpenCensus\Trace\Span;
+use OpenCensus\Trace\SpanData;
 use OpenCensus\Trace\Tracer\TracerInterface;
 
 /**
@@ -51,30 +51,28 @@ class FileExporter implements ExporterInterface
     }
 
     /**
-     * Report the provided Trace to a backend.
+     * Report the provided SpanData to a file in json format.
      *
-     * @param  TracerInterface $tracer
+     * @param SpanData[] $spans
      * @return bool
      */
-    public function report(TracerInterface $tracer)
+    public function export(array $spans)
     {
-        $spans = $this->convertSpans($tracer);
+        $spans = $this->convertSpans($spans);
         return file_put_contents($this->filename, json_encode($spans) . PHP_EOL, FILE_APPEND) !== false;
     }
 
     /**
      * Convert spans into array ready for serialization.
      *
-     * @param TracerInterface $tracer
+     * @param SpanData[] $spans
      * @return array Representation of the collected trace spans ready for serialization
      */
-    private function convertSpans(TracerInterface $tracer)
+    private function convertSpans(array $spans)
     {
-        $traceId = $tracer->spanContext()->traceId();
-
-        return array_map(function (Span $span) use ($traceId) {
+        return array_map(function (SpanData $span) use ($traceId) {
             return [
-                'traceId' => $traceId,
+                'traceId' => $span->traceId(),
                 'name' => $span->name(),
                 'spanId' => $span->spanId(),
                 'parentSpanId' => $span->parentSpanId(),
@@ -87,6 +85,6 @@ class FileExporter implements ExporterInterface
                 'links' => $span->links(),
                 'sameProcessAsParentSpan' => $span->sameProcessAsParentSpan(),
             ];
-        }, $tracer->spans());
+        }, $spans);
     }
 }

--- a/src/Trace/Exporter/LoggerExporter.php
+++ b/src/Trace/Exporter/LoggerExporter.php
@@ -17,7 +17,7 @@
 
 namespace OpenCensus\Trace\Exporter;
 
-use OpenCensus\Trace\Tracer\TracerInterface;
+use OpenCensus\Trace\SpanData;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -65,13 +65,13 @@ class LoggerExporter implements ExporterInterface
     /**
      * Report the provided Trace to a backend.
      *
-     * @param  TracerInterface $tracer
+     * @param SpanData[] $spans
      * @return bool
      */
-    public function report(TracerInterface $tracer)
+    public function export(array $spans)
     {
         try {
-            $this->logger->log($this->level, json_encode($tracer->spans()));
+            $this->logger->log($this->level, json_encode($spans));
         } catch (\Exception $e) {
             error_log('Reporting the Trace data failed: ' . $e->getMessage());
             return false;

--- a/src/Trace/Exporter/NullExporter.php
+++ b/src/Trace/Exporter/NullExporter.php
@@ -36,10 +36,10 @@ class NullExporter implements ExporterInterface
     /**
      * Does nothing.
      *
-     * @param  TracerInterface $tracer
+     * @param SpanData[] $spans
      * @return bool
      */
-    public function report(TracerInterface $tracer)
+    public function export(array $spans)
     {
         return true;
     }

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -201,26 +201,6 @@ class Span
     }
 
     /**
-     * Retrive the trace id for this span.
-     *
-     * @return string
-     */
-    public function traceId()
-    {
-        return $this->traceId;
-    }
-
-    /**
-     * Retrieve the start time for this span.
-     *
-     * @return \DateTimeInterface
-     */
-    public function startTime()
-    {
-        return $this->startTime;
-    }
-
-    /**
      * Set the start time for this span.
      *
      * @param  \DateTimeInterface|int|float $when [optional] The start time of
@@ -230,16 +210,6 @@ class Span
     public function setStartTime($when = null)
     {
         $this->startTime = $this->formatDate($when);
-    }
-
-    /**
-     * Retrieve the end time for this span.
-     *
-     * @return \DateTimeInterface
-     */
-    public function endTime()
-    {
-        return $this->endTime;
     }
 
     /**
@@ -265,23 +235,28 @@ class Span
     }
 
     /**
-     * Retrieve the ID of this span's parent if it exists.
+     * Return a read-only version of this span.
      *
-     * @return string
+     * @return SpanData
      */
-    public function parentSpanId()
+    public function spanData()
     {
-        return $this->parentSpanId;
-    }
-
-    /**
-     * Retrieve the name of this span.
-     *
-     * @return string
-     */
-    public function name()
-    {
-        return $this->name;
+        return new SpanData(
+            $this->name,
+            $this->traceId,
+            $this->spanId,
+            $this->startTime,
+            $this->endTime,
+            [
+                'parentSpanId' => $this->parentSpanId,
+                'attributes' => $this->attributes,
+                'timeEvents' => $this->timeEvents,
+                'links' => $this->links,
+                'status' => $this->status,
+                'sameProcessAsParentSpan' => $this->sameProcessAsParentSpan,
+                'stackTrace' => $this->stackTrace
+            ]
+        );
     }
 
     /**
@@ -307,16 +282,6 @@ class Span
     }
 
     /**
-     * Return the time events for this span.
-     *
-     * @return TimeEvent[]
-     */
-    public function timeEvents()
-    {
-        return $this->timeEvents;
-    }
-
-    /**
      * Add links to this span.
      *
      * @param Link[] $links
@@ -339,16 +304,6 @@ class Span
     }
 
     /**
-     * Return the links for this span.
-     *
-     * @return Link[]
-     */
-    public function links()
-    {
-        return $this->links;
-    }
-
-    /**
      * Set the status for this span.
      *
      * @param int $code The status code
@@ -357,36 +312,6 @@ class Span
     public function setStatus($code, $message)
     {
         $this->status = new Status($code, $message);
-    }
-
-    /**
-     * Retrieve the final status for this span.
-     *
-     * @return Status
-     */
-    public function status()
-    {
-        return $this->status;
-    }
-
-    /**
-     * Retrieve the stackTrace at the moment this span was created
-     *
-     * @return array
-     */
-    public function stackTrace()
-    {
-        return $this->stackTrace;
-    }
-
-    /**
-     * Whether or not this span is in the same process as its parent.
-     *
-     * @return bool
-     */
-    public function sameProcessAsParentSpan()
-    {
-        return $this->sameProcessAsParentSpan;
     }
 
     /**
@@ -448,7 +373,7 @@ class Span
     private function generateSpanName()
     {
         // Try to find the first stacktrace class entry that doesn't start with OpenCensus\Trace
-        foreach ($this->stackTrace() as $st) {
+        foreach ($this->stackTrace as $st) {
             $st += ['line' => null];
             if (!array_key_exists('class', $st)) {
                 return implode('/', array_filter(['app', basename($st['file']), $st['function'], $st['line']]));

--- a/src/Trace/SpanData.php
+++ b/src/Trace/SpanData.php
@@ -152,8 +152,8 @@ class SpanData
         $name,
         $traceId,
         $spanId,
-        \DateTimeInterface $startTime,
-        \DateTimeInterface $endTime,
+        \DateTimeInterface $startTime = null,
+        \DateTimeInterface $endTime = null,
         array $options = []
     ) {
         $options += [

--- a/src/Trace/Tracer/ExtensionTracer.php
+++ b/src/Trace/Tracer/ExtensionTracer.php
@@ -81,17 +81,18 @@ class ExtensionTracer implements TracerInterface
      */
     public function withSpan(Span $span)
     {
-        $startTime = $span->startTime()
-            ? (float)($span->startTime()->format('U.u'))
+        $spanData = $span->spanData();
+        $startTime = $spanData->startTime()
+            ? (float)($spanData->startTime()->format('U.u'))
             : microtime(true);
         $info = [
-            'spanId' => $span->spanId(),
-            'parentSpanId' => $span->parentSpanId(),
+            'spanId' => $spanData->spanId(),
+            'parentSpanId' => $spanData->parentSpanId(),
             'startTime' => $startTime,
-            'attributes' => $span->attributes(),
-            'stackTrace' => $span->stackTrace()
+            'attributes' => $spanData->attributes(),
+            'stackTrace' => $spanData->stackTrace()
         ];
-        opencensus_trace_begin($span->name(), $info);
+        opencensus_trace_begin($spanData->name(), $info);
         return new Scope(function () {
             opencensus_trace_finish();
         });

--- a/tests/unit/Core/ContextTest.php
+++ b/tests/unit/Core/ContextTest.php
@@ -69,7 +69,7 @@ class ContextTest extends TestCase
     }
 
     /**
-     * @expectedException \PHPUnit\Framework\Error\Warning
+     * @expectedException PHPUnit\Framework\Error\Warning
      */
     public function testRestoringCurrentContextRequiresSameObject()
     {

--- a/tests/unit/Core/ContextTest.php
+++ b/tests/unit/Core/ContextTest.php
@@ -69,7 +69,7 @@ class ContextTest extends TestCase
     }
 
     /**
-     * @expectedException PHPUnit\Framework\Error\Warning
+     * @expectedException \PHPUnit\Framework\Error\Warning
      */
     public function testRestoringCurrentContextRequiresSameObject()
     {

--- a/tests/unit/Trace/Exporter/EchoExporterTest.php
+++ b/tests/unit/Trace/Exporter/EchoExporterTest.php
@@ -18,9 +18,7 @@
 namespace OpenCensus\Tests\Unit\Trace\Exporter;
 
 use OpenCensus\Trace\Exporter\EchoExporter;
-use OpenCensus\Trace\SpanContext;
 use OpenCensus\Trace\Span;
-use OpenCensus\Trace\Tracer\TracerInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,28 +26,17 @@ use PHPUnit\Framework\TestCase;
  */
 class EchoExporterTest extends TestCase
 {
-    private $tracer;
-
-    public function setUp()
-    {
-        $this->tracer = $this->prophesize(TracerInterface::class);
-    }
-
     public function testLogsTrace()
     {
-        $spans = [
-            new Span([
-                'name' => 'span',
-                'startTime' => microtime(true),
-                'endTime' => microtime(true) + 10
-            ])
-        ];
-
-        $this->tracer->spans()->willReturn($spans);
+        $span = new Span([
+            'name' => 'span',
+            'startTime' => microtime(true),
+            'endTime' => microtime(true) + 10
+        ]);
 
         ob_start();
-        $reporter = new EchoExporter();
-        $this->assertTrue($reporter->report($this->tracer->reveal()));
+        $exporter = new EchoExporter();
+        $this->assertTrue($exporter->export([$span->spanData()]));
         $output = ob_get_contents();
         ob_end_clean();
         $this->assertGreaterThan(0, strlen($output));

--- a/tests/unit/Trace/Exporter/FileExporterTest.php
+++ b/tests/unit/Trace/Exporter/FileExporterTest.php
@@ -18,9 +18,7 @@
 namespace OpenCensus\Tests\Unit\Trace\Exporter;
 
 use OpenCensus\Trace\Exporter\FileExporter;
-use OpenCensus\Trace\SpanContext;
 use OpenCensus\Trace\Span;
-use OpenCensus\Trace\Tracer\TracerInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,7 +32,6 @@ class FileExporterTest extends TestCase
     public function setUp()
     {
         $this->filename = tempnam(sys_get_temp_dir(), 'traces');
-        $this->tracer = $this->prophesize(TracerInterface::class);
     }
 
     public function tearDown()
@@ -44,19 +41,14 @@ class FileExporterTest extends TestCase
 
     public function testLogsTrace()
     {
-        $this->tracer->spanContext()->willReturn(new SpanContext());
+        $span = new Span([
+            'name' => 'span',
+            'startTime' => microtime(true),
+            'endTime' => microtime(true) + 10
+        ]);
 
-        $spans = [
-            new Span([
-                'name' => 'span',
-                'startTime' => microtime(true),
-                'endTime' => microtime(true) + 10
-            ])
-        ];
-        $this->tracer->spans()->willReturn($spans);
-
-        $reporter = new FileExporter($this->filename);
-        $this->assertTrue($reporter->report($this->tracer->reveal()));
+        $exporter = new FileExporter($this->filename);
+        $this->assertTrue($exporter->export([$span->spanData()]));
         $this->assertGreaterThan(0, strlen(@file_get_contents($this->filename)));
     }
 }

--- a/tests/unit/Trace/Exporter/StackdriverExporterTest.php
+++ b/tests/unit/Trace/Exporter/StackdriverExporterTest.php
@@ -23,7 +23,7 @@ use OpenCensus\Trace\Exporter\StackdriverExporter;
 use OpenCensus\Trace\SpanContext;
 use OpenCensus\Trace\Tracer\TracerInterface;
 use OpenCensus\Trace\Tracer\ContextTracer;
-use OpenCensus\Trace\Span as OpenCensusSpan;
+use OpenCensus\Trace\Span as OCSpan;
 use Prophecy\Argument;
 use Google\Cloud\Trace\Trace;
 use Google\Cloud\Trace\Span;
@@ -35,26 +35,37 @@ use PHPUnit\Framework\TestCase;
  */
 class StackdriverExporterTest extends TestCase
 {
+    /**
+     * @var TraceClient
+     */
     private $client;
+
+    /**
+     * @var SpanData[]
+     */
+    private $spans;
 
     public function setUp()
     {
         parent::setUp();
         $this->client = $this->prophesize(TraceClient::class);
+
+        $this->spans = array_map(function ($span) {
+            return $span->spanData();
+        }, [
+            new OCSpan([
+                'name' => 'span',
+                'startTime' => microtime(true),
+                'endTime' => microtime(true) + 10
+            ])
+        ]);
     }
 
     public function testFormatsTrace()
     {
-        $tracer = new ContextTracer(new SpanContext('testtraceid'));
-        $tracer->inSpan(['name' => 'main'], function () use ($tracer) {
-            $tracer->inSpan(['name' => 'span1'], 'usleep', [10]);
-            $tracer->inSpan(['name' => 'span2'], 'usleep', [20]);
-        });
+        $exporter = new StackdriverExporter(['client' => $this->client->reveal()]);
+        $spans = $exporter->convertSpans($this->spans);
 
-        $reporter = new StackdriverExporter(['client' => $this->client->reveal()]);
-        $spans = $reporter->convertSpans($tracer);
-
-        $this->assertCount(3, $spans);
         foreach ($spans as $span) {
             $this->assertInstanceOf(Span::class, $span);
             $this->assertInternalType('string', $span->name());
@@ -66,21 +77,19 @@ class StackdriverExporterTest extends TestCase
 
     public function testReportWithAnExceptionErrorLog()
     {
-        $tracer = new ContextTracer(new SpanContext('testtraceid'));
-        $tracer->inSpan(['name' => 'main'], function () {});
         $this->client->insert(Argument::any())->willThrow(
             new \Exception('error_log test')
         );
         $trace = $this->prophesize(Trace::class);
         $trace->setSpans(Argument::any())->shouldBeCalled();
         $this->client->trace(Argument::any())->willReturn($trace->reveal());
-        $reporter = new StackdriverExporter(
+        $exporter = new StackdriverExporter(
             ['client' => $this->client->reveal()]
         );
         $this->expectOutputString(
             'Reporting the Trace data failed: error_log test'
         );
-        $this->assertFalse($reporter->report($tracer));
+        $this->assertFalse($exporter->export($this->spans));
     }
 
     public function testStacktrace()
@@ -94,11 +103,14 @@ class StackdriverExporterTest extends TestCase
                 'type' => '::'
             ]
         ];
-        $tracer = new ContextTracer(new SpanContext('testtraceid'));
-        $tracer->inSpan(['stackTrace' => $stackTrace], function () {});
+        $span = new OCSpan([
+            'stackTrace' => $stackTrace
+        ]);
+        $span->setStartTime();
+        $span->setEndTime();
 
-        $reporter = new StackdriverExporter(['client' => $this->client->reveal()]);
-        $spans = $reporter->convertSpans($tracer);
+        $exporter = new StackdriverExporter();
+        $spans = $exporter->convertSpans([$span->spanData()]);
 
         $data = $spans[0]->jsonSerialize();
         $this->assertArrayHasKey('stackTrace', $data);
@@ -106,10 +118,8 @@ class StackdriverExporterTest extends TestCase
 
     public function testEmptyTrace()
     {
-        $tracer = new ContextTracer(new SpanContext('testtraceid'));
-
-        $reporter = new StackdriverExporter(['client' => $this->client->reveal()]);
-        $this->assertFalse($reporter->report($tracer));
+        $exporter = new StackdriverExporter();
+        $this->assertFalse($exporter->export([]));
     }
 
     /**
@@ -125,8 +135,16 @@ class StackdriverExporterTest extends TestCase
             ]
         ], function () {});
 
-        $exporter = new StackdriverExporter(['client' => $this->client->reveal()]);
-        $spans = $exporter->convertSpans($tracer);
+        $span = new OCSpan([
+            'attributes' => [
+                $key => $value
+            ]
+        ]);
+        $span->setStartTime();
+        $span->setEndTime();
+
+        $exporter = new StackdriverExporter();
+        $spans = $exporter->convertSpans([$span->spanData()]);
         $this->assertCount(1, $spans);
         $span = $spans[0];
 

--- a/tests/unit/Trace/Exporter/StackdriverExporterTest.php
+++ b/tests/unit/Trace/Exporter/StackdriverExporterTest.php
@@ -109,7 +109,7 @@ class StackdriverExporterTest extends TestCase
         $span->setStartTime();
         $span->setEndTime();
 
-        $exporter = new StackdriverExporter();
+        $exporter = new StackdriverExporter(['client' => $this->client->reveal()]);
         $spans = $exporter->convertSpans([$span->spanData()]);
 
         $data = $spans[0]->jsonSerialize();

--- a/tests/unit/Trace/Exporter/StackdriverExporterTest.php
+++ b/tests/unit/Trace/Exporter/StackdriverExporterTest.php
@@ -118,7 +118,7 @@ class StackdriverExporterTest extends TestCase
 
     public function testEmptyTrace()
     {
-        $exporter = new StackdriverExporter();
+        $exporter = new StackdriverExporter(['client' => $this->client->reveal()]);
         $this->assertFalse($exporter->export([]));
     }
 
@@ -143,7 +143,7 @@ class StackdriverExporterTest extends TestCase
         $span->setStartTime();
         $span->setEndTime();
 
-        $exporter = new StackdriverExporter();
+        $exporter = new StackdriverExporter(['client' => $this->client->reveal()]);
         $spans = $exporter->convertSpans([$span->spanData()]);
         $this->assertCount(1, $spans);
         $span = $spans[0];

--- a/tests/unit/Trace/Integrations/Guzzle/EventSubscriberTest.php
+++ b/tests/unit/Trace/Integrations/Guzzle/EventSubscriberTest.php
@@ -47,9 +47,8 @@ class EventSubscriberTest extends TestCase
 
     public function testAddsSpanContextHeader()
     {
-        $this->exporter->report(Argument::that(function ($tracer) {
-            $spans = $tracer->spans();
-            return count($spans) == 3 && $spans[2]->spanData()->name() == 'GuzzleHttp::request';
+        $this->exporter->export(Argument::that(function ($spans) {
+            return count($spans) == 3 && $spans[2]->name() == 'GuzzleHttp::request';
         }))->shouldBeCalled();
 
         $rt = Tracer::start($this->exporter->reveal(), [

--- a/tests/unit/Trace/Integrations/Guzzle/EventSubscriberTest.php
+++ b/tests/unit/Trace/Integrations/Guzzle/EventSubscriberTest.php
@@ -49,7 +49,7 @@ class EventSubscriberTest extends TestCase
     {
         $this->exporter->report(Argument::that(function ($tracer) {
             $spans = $tracer->spans();
-            return count($spans) == 3 && $spans[2]->name() == 'GuzzleHttp::request';
+            return count($spans) == 3 && $spans[2]->spanData()->name() == 'GuzzleHttp::request';
         }))->shouldBeCalled();
 
         $rt = Tracer::start($this->exporter->reveal(), [

--- a/tests/unit/Trace/Integrations/Guzzle/MiddlewareTest.php
+++ b/tests/unit/Trace/Integrations/Guzzle/MiddlewareTest.php
@@ -45,9 +45,8 @@ class MiddlewareTest extends TestCase
 
     public function testAddsSpanContextHeader()
     {
-        $this->exporter->report(Argument::that(function ($tracer) {
-            $spans = $tracer->spans();
-            return count($spans) == 3 && $spans[2]->spanData()->name() == 'GuzzleHttp::request';
+        $this->exporter->export(Argument::that(function ($spans) {
+            return count($spans) == 3 && $spans[2]->name() == 'GuzzleHttp::request';
         }))->shouldBeCalled();
 
         $rt = Tracer::start($this->exporter->reveal(), [

--- a/tests/unit/Trace/Integrations/Guzzle/MiddlewareTest.php
+++ b/tests/unit/Trace/Integrations/Guzzle/MiddlewareTest.php
@@ -47,7 +47,7 @@ class MiddlewareTest extends TestCase
     {
         $this->exporter->report(Argument::that(function ($tracer) {
             $spans = $tracer->spans();
-            return count($spans) == 3 && $spans[2]->name() == 'GuzzleHttp::request';
+            return count($spans) == 3 && $spans[2]->spanData()->name() == 'GuzzleHttp::request';
         }))->shouldBeCalled();
 
         $rt = Tracer::start($this->exporter->reveal(), [

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -31,7 +31,7 @@ use PHPUnit\Framework\TestCase;
  */
 class RequestHandlerTest extends TestCase
 {
-    private $reporter;
+    private $exporter;
 
     private $sampler;
 
@@ -40,7 +40,7 @@ class RequestHandlerTest extends TestCase
         if (extension_loaded('opencensus')) {
             opencensus_trace_clear();
         }
-        $this->reporter = $this->prophesize(ExporterInterface::class);
+        $this->exporter = $this->prophesize(ExporterInterface::class);
         $this->sampler = $this->prophesize(SamplerInterface::class);
     }
 
@@ -49,7 +49,7 @@ class RequestHandlerTest extends TestCase
         $this->sampler->shouldSample()->willReturn(true);
 
         $rt = new RequestHandler(
-            $this->reporter->reveal(),
+            $this->exporter->reveal(),
             $this->sampler->reveal(),
             new HttpHeaderPropagator(),
             [
@@ -74,7 +74,7 @@ class RequestHandlerTest extends TestCase
     public function testCanParseParentContext()
     {
         $rt = new RequestHandler(
-            $this->reporter->reveal(),
+            $this->exporter->reveal(),
             $this->sampler->reveal(),
             new HttpHeaderPropagator(),
             [
@@ -93,7 +93,7 @@ class RequestHandlerTest extends TestCase
     public function testForceEnabledContextHeader()
     {
         $rt = new RequestHandler(
-            $this->reporter->reveal(),
+            $this->exporter->reveal(),
             $this->sampler->reveal(),
             new HttpHeaderPropagator(),
             [
@@ -111,7 +111,7 @@ class RequestHandlerTest extends TestCase
     public function testForceDisabledContextHeader()
     {
         $rt = new RequestHandler(
-            $this->reporter->reveal(),
+            $this->exporter->reveal(),
             $this->sampler->reveal(),
             new HttpHeaderPropagator(),
             [

--- a/tests/unit/Trace/Tracer/AbstractTracerTest.php
+++ b/tests/unit/Trace/Tracer/AbstractTracerTest.php
@@ -47,9 +47,9 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $span = $spans[0];
-        $this->assertEquals('test', $span->name());
-        $this->assertEquals($parentSpanId, $span->parentSpanId());
+        $spanData = $spans[0]->spanData();
+        $this->assertEquals('test', $spanData->name());
+        $this->assertEquals($parentSpanId, $spanData->parentSpanId());
     }
 
     public function testAddsAttributesToCurrentSpan()
@@ -64,9 +64,9 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $span = $spans[1];
-        $this->assertEquals('inner', $span->name());
-        $attributes = $span->attributes();
+        $spanData = $spans[1]->spanData();
+        $this->assertEquals('inner', $spanData->name());
+        $attributes = $spanData->attributes();
         $this->assertArrayHasKey('foo', $attributes);
         $this->assertEquals('bar', $attributes['foo']);
     }
@@ -84,9 +84,9 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $span = $spans[0];
-        $this->assertEquals('root', $span->name());
-        $attributes = $span->attributes();
+        $spanData = $spans[0]->spanData();
+        $this->assertEquals('root', $spanData->name());
+        $attributes = $spanData->attributes();
         $this->assertArrayHasKey('foo', $attributes);
         $this->assertEquals('bar', $attributes['foo']);
     }
@@ -96,8 +96,8 @@ abstract class AbstractTracerTest extends TestCase
         $class = $this->getTracerClass();
         $tracer = new $class();
         $tracer->inSpan(['name' => 'test'], function () {});
-        $span = $tracer->spans()[0];
-        $stackframe = $span->stackTrace()[0];
+        $spanData = $tracer->spans()[0]->spanData();;
+        $stackframe = $spanData->stackTrace()[0];
         $this->assertEquals('testPersistsBacktrace', $stackframe['function']);
         $this->assertEquals(self::class, $stackframe['class']);
     }
@@ -125,7 +125,10 @@ abstract class AbstractTracerTest extends TestCase
         usleep(100);
         $scope->close();
 
-        $this->assertEquivalentTimestamps($span->startTime(), $tracer->spans()[0]->startTime());
+        $this->assertEquivalentTimestamps(
+            $span->spanData()->startTime(),
+            $tracer->spans()[0]->spanData()->startTime()
+        );
     }
 
     public function testAddsAnnotations()
@@ -140,10 +143,10 @@ abstract class AbstractTracerTest extends TestCase
         });
 
         $spans = $tracer->spans();
-        $rootSpan = $spans[0];
-        $this->assertCount(1, $rootSpan->timeEvents());
-        $innerSpan = $spans[1];
-        $this->assertCount(1, $rootSpan->timeEvents());
+        $rootSpanData = $spans[0]->spanData();
+        $this->assertCount(1, $rootSpanData->timeEvents());
+        $innerSpanData = $spans[1]->spanData();
+        $this->assertCount(1, $innerSpanData->timeEvents());
     }
 
     public function testAddsAnnotationToRootSpan()
@@ -162,9 +165,10 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $span = $spans[0];
-        $this->assertEquals('root', $span->name());
-        $this->assertCount(1, $span->timeEvents());
+
+        $spanData = $spans[0]->spanData();
+        $this->assertEquals('root', $spanData->name());
+        $this->assertCount(1, $spanData->timeEvents());
     }
 
     public function testAddsLinks()
@@ -179,10 +183,10 @@ abstract class AbstractTracerTest extends TestCase
         });
 
         $spans = $tracer->spans();
-        $rootSpan = $spans[0];
-        $this->assertCount(1, $rootSpan->links());
-        $innerSpan = $spans[1];
-        $this->assertCount(1, $rootSpan->links());
+        $rootSpanData = $spans[0]->spanData();
+        $this->assertCount(1, $rootSpanData->links());
+        $innerSpanData = $spans[1]->spanData();
+        $this->assertCount(1, $innerSpanData->links());
     }
 
     public function testAddsLinkToRootSpan()
@@ -200,9 +204,10 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $span = $spans[0];
-        $this->assertEquals('root', $span->name());
-        $this->assertCount(1, $span->links());
+        $spanData = $spans[0]->spanData();
+
+        $this->assertEquals('root', $spanData->name());
+        $this->assertCount(1, $spanData->links());
     }
 
     public function testAddMessageEvents()
@@ -217,10 +222,10 @@ abstract class AbstractTracerTest extends TestCase
         });
 
         $spans = $tracer->spans();
-        $rootSpan = $spans[0];
-        $this->assertCount(1, $rootSpan->timeEvents());
-        $innerSpan = $spans[1];
-        $this->assertCount(1, $rootSpan->timeEvents());
+        $rootSpanData = $spans[0]->spanData();
+        $this->assertCount(1, $rootSpanData->timeEvents());
+        $innerSpanData = $spans[1]->spanData();
+        $this->assertCount(1, $innerSpanData->timeEvents());
     }
 
     public function testAddsMessageEventToRootSpan()
@@ -238,9 +243,10 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $span = $spans[0];
-        $this->assertEquals('root', $span->name());
-        $this->assertCount(1, $span->timeEvents());
+        $spanData = $spans[0]->spanData();
+
+        $this->assertEquals('root', $spanData->name());
+        $this->assertCount(1, $spanData->timeEvents());
     }
 
     public function testInSpanSetsDefaultStartTime()
@@ -253,10 +259,10 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $span = $spans[0];
+        $spanData = $spans[0]->spanData();
 
         // #131 - Span should be initialized with current time, not the epoch.
-        $this->assertNotEquals(0, $span->startTime()->getTimestamp());
+        $this->assertNotEquals(0, $spanData->startTime()->getTimestamp());
     }
 
     public function testStackTraceShouldBeSet()
@@ -269,10 +275,10 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $span = $spans[0];
+        $spanData = $spans[0]->spanData();
 
-        $this->assertInternalType('array', $span->stackTrace());
-        $this->assertNotEmpty($span->stackTrace());
+        $this->assertInternalType('array', $spanData->stackTrace());
+        $this->assertNotEmpty($spanData->stackTrace());
     }
 
     public function testAttributesShouldBeSet()
@@ -285,10 +291,10 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $span = $spans[0];
+        $spanData = $spans[0]->spanData();
 
-        $this->assertInternalType('array', $span->attributes());
-        $this->assertEmpty($span->attributes());
+        $this->assertInternalType('array', $spanData->attributes());
+        $this->assertEmpty($spanData->attributes());
     }
 
     public function testLinksShouldBeSet()
@@ -301,10 +307,10 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $span = $spans[0];
+        $spanData = $spans[0]->spanData();
 
-        $this->assertInternalType('array', $span->links());
-        $this->assertEmpty($span->links());
+        $this->assertInternalType('array', $spanData->links());
+        $this->assertEmpty($spanData->links());
     }
 
     public function testTimeEventsShouldBeSet()
@@ -317,10 +323,10 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $span = $spans[0];
+        $spanData = $spans[0]->spanData();
 
-        $this->assertInternalType('array', $span->timeEvents());
-        $this->assertEmpty($span->timeEvents());
+        $this->assertInternalType('array', $spanData->timeEvents());
+        $this->assertEmpty($spanData->timeEvents());
     }
 
     private function assertEquivalentTimestamps($expected, $value)


### PR DESCRIPTION
Fixes #58
Fixes #143

`ExporterInterface` is now `export(array $spans)` which accepts an array of read-only `SpanData` objects.
`Span` objects are now read-only and meant for collecting data. You can get their read-only version via `$span->spanData()`