### PR TITLE
Set defaults for sameProcessAsParentSpan

### DIFF
--- a/ext/opencensus_trace_span.h
+++ b/ext/opencensus_trace_span.h
@@ -32,6 +32,7 @@ typedef struct opencensus_trace_span_t {
     double stop;
     struct opencensus_trace_span_t *parent;
     zval stackTrace;
+    zend_long same_process_as_parent_span;
 
     // zend_string* => zval*
     HashTable *attributes;

--- a/ext/tests/manual_spans_default_options.phpt
+++ b/ext/tests/manual_spans_default_options.phpt
@@ -45,6 +45,7 @@ Array
                 )
 
             [kind:protected] => SPAN_KIND_UNSPECIFIED
+            [sameProcessAsParentSpan:protected] => 1
         )
 
     [1] => OpenCensus\Trace\Ext\Span Object
@@ -71,6 +72,7 @@ Array
                 )
 
             [kind:protected] => SPAN_KIND_UNSPECIFIED
+            [sameProcessAsParentSpan:protected] => 1
         )
 
 )

--- a/ext/tests/span_same_process_as_parent_span.phpt
+++ b/ext/tests/span_same_process_as_parent_span.phpt
@@ -1,0 +1,22 @@
+--TEST--
+OpenCensus Trace: Set span sameProcessAsParentSpan
+--FILE--
+<?php
+opencensus_trace_begin('/', [
+    'startTime' => 0.1,
+    'sameProcessAsParentSpan' => true
+]);
+opencensus_trace_begin('inner-1', [
+    'sameProcessAsParentSpan' => false
+]);
+opencensus_trace_finish();
+opencensus_trace_finish();
+$traces = opencensus_trace_list();
+echo "Number of traces: " . count($traces) . "\n";
+var_dump($traces[0]->sameProcessAsParentSpan());
+var_dump($traces[1]->sameProcessAsParentSpan());
+?>
+--EXPECT--
+Number of traces: 2
+bool(true)
+bool(false)

--- a/src/Trace/RequestHandler.php
+++ b/src/Trace/RequestHandler.php
@@ -116,7 +116,8 @@ class RequestHandler
             'startTime' => $this->startTimeFromHeaders($this->headers),
             'name' => $this->nameFromHeaders($this->headers),
             'attributes' => [],
-            'kind' => Span::KIND_SERVER
+            'kind' => Span::KIND_SERVER,
+            'sameProcessAsParentSpan' => false
         ];
         $this->rootSpan = $this->tracer->startSpan($spanOptions);
         $this->scope = $this->tracer->withSpan($this->rootSpan);

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -174,7 +174,7 @@ class Span
             'links' => [],
             'parentSpanId' => null,
             'status' => null,
-            'sameProcessAsParentSpan' => null,
+            'sameProcessAsParentSpan' => true,
             'kind' => self::KIND_UNSPECIFIED
         ];
 

--- a/src/Trace/Tracer/ContextTracer.php
+++ b/src/Trace/Tracer/ContextTracer.php
@@ -60,7 +60,9 @@ class ContextTracer implements TracerInterface
      */
     public function inSpan(array $spanOptions, callable $callable, array $arguments = [])
     {
-        $span = $this->startSpan($spanOptions);
+        $span = $this->startSpan($spanOptions + [
+            'sameProcessAsParentSpan' => !empty($this->spans)
+        ]);
         $scope = $this->withSpan($span);
         try {
             return call_user_func_array($callable, $arguments);


### PR DESCRIPTION
The first span defaults to false (from an external process).
Subsequent spans default to true (running in the same PHP process).

Fixes #122 