### PR TITLE
SpanData now implements stackTraceHashId()

### DIFF
--- a/src/Trace/SpanData.php
+++ b/src/Trace/SpanData.php
@@ -318,8 +318,11 @@ class SpanData
     public function stackTraceHashId()
     {
         if (!isset($this->stackTraceHashId)) {
-            // take the lower 16 digits of the md5 and convert to an int
-            $this->stackTraceHashId = hexdec(substr(md5(serialize($this->stackTrace)), -16));
+            // take the lower 16 (8 for 32-bit PHP) digits of the md5 and
+            // convert to an int
+            $digits = PHP_INT_SIZE * -2;
+            $md5 = md5(serialize($this->stackTrace));
+            $this->stackTraceHashId = hexdec(substr($md5, $digits));
         }
         return $this->stackTraceHashId;
     }

--- a/src/Trace/SpanData.php
+++ b/src/Trace/SpanData.php
@@ -137,6 +137,13 @@ class SpanData
     private $kind;
 
     /**
+     * An optional value to de-dup the stackTrace array.
+     *
+     * @var int
+     */
+    private $stackTraceHashId;
+
+    /**
      * Instantiate a new SpanData instance.
      *
      * @param string $name The name of the span.
@@ -301,6 +308,20 @@ class SpanData
     public function stackTrace()
     {
         return $this->stackTrace;
+    }
+
+    /**
+     * Return a hash id for this span's stackTrace.
+     *
+     * @return id
+     */
+    public function stackTraceHashId()
+    {
+        if (!isset($this->stackTraceHashId)) {
+            // take the lower 16 digits of the md5 and convert to an int
+            $this->stackTraceHashId = hexdec(substr(md5(serialize($this->stackTrace)), -16));
+        }
+        return $this->stackTraceHashId;
     }
 
     /**

--- a/src/Trace/SpanData.php
+++ b/src/Trace/SpanData.php
@@ -137,9 +137,10 @@ class SpanData
     private $kind;
 
     /**
-     * An optional value to de-dup the stackTrace array.
+     * An optional value to de-dup the stackTrace array. Represented as a
+     * hexadecimal string.
      *
-     * @var int
+     * @var string
      */
     private $stackTraceHashId;
 
@@ -311,18 +312,16 @@ class SpanData
     }
 
     /**
-     * Return a hash id for this span's stackTrace.
+     * Return a hash id for this span's stackTrace in hexadecimal
      *
-     * @return id
+     * @return string
      */
     public function stackTraceHashId()
     {
         if (!isset($this->stackTraceHashId)) {
-            // take the lower 16 (8 for 32-bit PHP) digits of the md5 and
-            // convert to an int
-            $digits = PHP_INT_SIZE * -2;
+            // take the lower 16 digits of the md5
             $md5 = md5(serialize($this->stackTrace));
-            $this->stackTraceHashId = hexdec(substr($md5, $digits));
+            $this->stackTraceHashId = substr($md5, 16);
         }
         return $this->stackTraceHashId;
     }

--- a/tests/unit/Trace/SpanDataTest.php
+++ b/tests/unit/Trace/SpanDataTest.php
@@ -85,8 +85,7 @@ class SpanDataTest extends TestCase
         ]);
 
         $hashId = $spanData->stackTraceHashId();
-        $this->assertInternalType('int', $hashId);
-        $this->assertNotEquals(0, $hashId);
+        $this->assertInternalType('string', $hashId);
         $this->assertEquals($hashId, $spanData2->stackTraceHashId());
     }
 }

--- a/tests/unit/Trace/SpanDataTest.php
+++ b/tests/unit/Trace/SpanDataTest.php
@@ -70,4 +70,23 @@ class SpanDataTest extends TestCase
             ['kind', Span::KIND_SERVER]
         ];
     }
+
+    public function testStackTraceHashIdIsRepeatable()
+    {
+        $stackTrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+        $startTime = new \DateTime();
+        $endTime = new \DateTime();
+        $spanData = new SpanData('span-name', 'aaa', 'bbb', $startTime, $endTime, [
+            'stackTrace' => $stackTrace
+        ]);
+
+        $spanData2 = new SpanData('span-name2', 'aaa', 'bbb', $startTime, $endTime, [
+            'stackTrace' => $stackTrace
+        ]);
+
+        $hashId = $spanData->stackTraceHashId();
+        $this->assertInternalType('int', $hashId);
+        $this->assertNotEquals(0, $hashId);
+        $this->assertEquals($hashId, $spanData2->stackTraceHashId());
+    }
 }


### PR DESCRIPTION
Fixes #121 

Returning the `stackTraceHashId` as a 16-digit hex string as PHP's built-in integer is signed.