### PR TITLE
StackdriverExporter should report g.co/agent attribute

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,8 @@ The PHP library and extension are released independently of each other.
 
 ## Packagist Package
 
+1. Bump `VERSION` constant in [`src/Version.php`][version-file]
+
 1. Create a GitHub release.
 
 1. Click `Update` from the admin view of the [opencensus/opencensus][packagist] package.
@@ -28,5 +30,6 @@ The PHP library and extension are released independently of each other.
 
 1. Upload the new release to PECL from the [admin console][pecl-upload].
 
+[version-file]: https://github.com/census-instrumentation/opencensus-php/tree/master/src/Version.php
 [packagist]: https://packagist.org/packages/opencensus/opencensus
 [pecl-upload]: https://pecl.php.net/release-upload.php

--- a/src/Version.php
+++ b/src/Version.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus;
+
+/**
+ * This class provides a constant for the current version of this library.
+ */
+class Version
+{
+    const VERSION = '0.4.1';
+}

--- a/tests/unit/Trace/Exporter/StackdriverExporterTest.php
+++ b/tests/unit/Trace/Exporter/StackdriverExporterTest.php
@@ -163,4 +163,31 @@ class StackdriverExporterTest extends TestCase
             ['http.user_agent', 'user agent', '/http/user_agent', 'user agent']
         ];
     }
+
+    public function testReportsVersionAttribute()
+    {
+        $trace = $this->prophesize(Trace::class);
+        $trace->setSpans(Argument::that(function ($spans) {
+            $this->assertCount(1, $spans);
+            $attributes = $spans[0]->jsonSerialize()['attributes'];
+            $this->assertArrayHasKey('g.co/agent', $attributes);
+            $this->assertRegexp('/\d+\.\d+\.\d+/', $attributes['g.co/agent']);
+            return true;
+        }))->shouldBeCalled();
+        $this->client->trace('aaa')->willReturn($trace->reveal());
+        $this->client->insert(Argument::type(Trace::class))
+            ->willReturn(true)->shouldBeCalled();
+
+        $span = new OCSpan([
+            'traceId' => 'aaa',
+            'attributes' => [
+                $key => $value
+            ]
+        ]);
+        $span->setStartTime();
+        $span->setEndTime();
+
+        $exporter = new StackdriverExporter(['client' => $this->client->reveal()]);
+        $this->assertTrue($exporter->export([$span->spanData()]));
+    }
 }


### PR DESCRIPTION
This was removed in #146 when we moved collection of common root span attributes to all requests (not only if you were using the StackdriverExporter).

This PR also adds a `\OpenCensus\Version::VERSION` constant.