### PR TITLE
Fix bug that can cause the timestamp to be 1 second later.

### DIFF
--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -342,18 +342,26 @@ class Span
     {
         if (!$when) {
             // now
-            list($usec, $sec) = explode(' ', microtime());
-            $micro = sprintf("%06d", $usec * 1000000);
-            $when = new \DateTime(date('Y-m-d H:i:s.' . $micro));
+            $when = formatFloatTimeToDate(microtime(true));
         } elseif (is_numeric($when)) {
-            // Expect that this is a timestamp
-            $micro = sprintf("%06d", ($when - floor($when)) * 1000000);
-            $when = new \DateTime(date('Y-m-d H:i:s.'. $micro, (int) $when));
+            $when = formatFloatTimeToDate($when);
         } elseif (!$when instanceof \DateTimeInterface) {
             throw new \InvalidArgumentException('Invalid date format. Must be a \DateTimeInterface or numeric.');
         }
         $when->setTimezone(new \DateTimeZone('UTC'));
         return $when;
+    }
+
+    /**
+     * Converst a float timestamp into a \DateTimeInterface object.
+     * 
+     * @param float $when The Unix timestamp to be converted.
+     * @return \DateTimeInterface
+     */
+    private function formatFloatTimeToDate($when) {
+        $sec = floor($when);
+        $micro = sprintf("%06d", ($when - $sec) * 1000000);
+        return new \DateTime(date('Y-m-d H:i:s.'. $micro, $sec));
     }
 
     /**

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -342,9 +342,9 @@ class Span
     {
         if (!$when) {
             // now
-            $when = formatFloatTimeToDate(microtime(true));
+            $when = $this->formatFloatTimeToDate(microtime(true));
         } elseif (is_numeric($when)) {
-            $when = formatFloatTimeToDate($when);
+            $when = $this->formatFloatTimeToDate($when);
         } elseif (!$when instanceof \DateTimeInterface) {
             throw new \InvalidArgumentException('Invalid date format. Must be a \DateTimeInterface or numeric.');
         }

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -353,7 +353,7 @@ class Span
     }
 
     /**
-     * Converst a float timestamp into a \DateTimeInterface object.
+     * Converts a float timestamp into a \DateTimeInterface object.
      * 
      * @param float $when The Unix timestamp to be converted.
      * @return \DateTimeInterface

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -354,11 +354,12 @@ class Span
 
     /**
      * Converts a float timestamp into a \DateTimeInterface object.
-     * 
+     *
      * @param float $when The Unix timestamp to be converted.
      * @return \DateTimeInterface
      */
-    private function formatFloatTimeToDate($when) {
+    private function formatFloatTimeToDate($when)
+    {
         $sec = floor($when);
         $micro = sprintf("%06d", ($when - $sec) * 1000000);
         return new \DateTime(date('Y-m-d H:i:s.'. $micro, $sec));


### PR DESCRIPTION
This can happen because time was read twice when $when was null, once to get the usec and once to get the seconds, so if the initial time was 1.999 and second time was 2.001 then the result will be 2.999 which is 1 second later.