### PR TITLE
Prepare v0.4.2

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -22,5 +22,5 @@ namespace OpenCensus;
  */
 class Version
 {
-    const VERSION = '0.4.1';
+    const VERSION = '0.4.2';
 }


### PR DESCRIPTION
* Adds `Version::VERSION` constant. (#160)
* Fix bug where timestamp can be 1 second later. (#161)
* Clean up test warnings (#164)