### PR TITLE
WIP: Allow collecting time events and links from the global tracer

### DIFF
--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -97,6 +97,7 @@
 #include "opencensus_trace_link.h"
 #include "opencensus_trace_message_event.h"
 #include "Zend/zend_alloc.h"
+#include "Zend/zend_variables.h"
 
 zend_class_entry* opencensus_trace_span_ce = NULL;
 
@@ -499,7 +500,7 @@ int opencensus_trace_span_add_annotation(opencensus_trace_span_t *span, zend_str
     annotation->time_event.time = opencensus_now();
     annotation->description = zend_string_copy(description);
     if (options != NULL) {
-        ZVAL_COPY(&annotation->options, options);
+        zend_hash_merge(Z_ARR(annotation->options), Z_ARR_P(options), zval_add_ref, 1);
     }
 
     zend_hash_next_index_insert_ptr(span->time_events, annotation);
@@ -513,7 +514,7 @@ int opencensus_trace_span_add_link(opencensus_trace_span_t *span, zend_string *t
     link->trace_id = zend_string_copy(trace_id);
     link->span_id = zend_string_copy(span_id);
     if (options != NULL) {
-        ZVAL_COPY(&link->options, options);
+        zend_hash_merge(Z_ARR(link->options), Z_ARR_P(options), zval_add_ref, 1);
     }
 
     zend_hash_next_index_insert_ptr(span->links, link);
@@ -528,7 +529,7 @@ int opencensus_trace_span_add_message_event(opencensus_trace_span_t *span, zend_
     message_event->type = zend_string_copy(type);
     message_event->id = zend_string_copy(id);
     if (options != NULL) {
-        ZVAL_COPY(&message_event->options, options);
+        zend_hash_merge(Z_ARR(message_event->options), Z_ARR_P(options), zval_add_ref, 1);
     }
 
     zend_hash_next_index_insert_ptr(span->time_events, message_event);

--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -579,6 +579,8 @@ int opencensus_trace_span_apply_span_options(opencensus_trace_span_t *span, zval
             if (Z_TYPE_P(v) == IS_FALSE) {
                 span->same_process_as_parent_span = 0;
             }
+        } else if (strcmp(ZSTR_VAL(k), "stackTrace") == 0) {
+            ZVAL_COPY(&span->stackTrace, v);
         }
     } ZEND_HASH_FOREACH_END();
     return SUCCESS;

--- a/ext/opencensus_trace_span.c
+++ b/ext/opencensus_trace_span.c
@@ -498,6 +498,9 @@ int opencensus_trace_span_add_annotation(opencensus_trace_span_t *span, zend_str
     opencensus_trace_annotation_t *annotation = opencensus_trace_annotation_alloc();
     annotation->time_event.time = opencensus_now();
     annotation->description = zend_string_copy(description);
+    if (options != NULL) {
+        ZVAL_COPY(&annotation->options, options);
+    }
 
     zend_hash_next_index_insert_ptr(span->time_events, annotation);
     return SUCCESS;
@@ -509,6 +512,9 @@ int opencensus_trace_span_add_link(opencensus_trace_span_t *span, zend_string *t
     opencensus_trace_link_t *link = opencensus_trace_link_alloc();
     link->trace_id = zend_string_copy(trace_id);
     link->span_id = zend_string_copy(span_id);
+    if (options != NULL) {
+        ZVAL_COPY(&link->options, options);
+    }
 
     zend_hash_next_index_insert_ptr(span->links, link);
     return FAILURE;
@@ -521,6 +527,9 @@ int opencensus_trace_span_add_message_event(opencensus_trace_span_t *span, zend_
     message_event->time_event.time = opencensus_now();
     message_event->type = zend_string_copy(type);
     message_event->id = zend_string_copy(id);
+    if (options != NULL) {
+        ZVAL_COPY(&message_event->options, options);
+    }
 
     zend_hash_next_index_insert_ptr(span->time_events, message_event);
     return SUCCESS;

--- a/ext/tests/annotations.phpt
+++ b/ext/tests/annotations.phpt
@@ -4,7 +4,11 @@ OpenCensus Trace: Test setting annotations
 <?php
 
 opencensus_trace_begin('root', ['spanId' => '1234']);
-opencensus_trace_add_annotation('foo');
+opencensus_trace_add_annotation('foo', [
+    'attributes' => [
+        'foo' => 'bar'
+    ]
+]);
 opencensus_trace_begin('inner', []);
 opencensus_trace_add_annotation('asdf', ['spanId' => '1234']);
 opencensus_trace_add_annotation('abc');
@@ -29,6 +33,11 @@ Array
             [time:protected] => %d.%d
             [options:protected] => Array
                 (
+                    [attributes] => Array
+                        (
+                            [foo] => bar
+                        )
+
                 )
 
         )
@@ -39,6 +48,7 @@ Array
             [time:protected] => %d.%d
             [options:protected] => Array
                 (
+                    [spanId] => 1234
                 )
 
         )

--- a/ext/tests/links.phpt
+++ b/ext/tests/links.phpt
@@ -4,7 +4,9 @@ OpenCensus Trace: Test setting links
 <?php
 
 opencensus_trace_begin('root', ['spanId' => '1234']);
-opencensus_trace_add_link('traceId', 'spanId');
+opencensus_trace_add_link('traceId', 'spanId', [
+    'type' => 'CHILD_LINKED_SPAN'
+]);
 opencensus_trace_begin('inner', []);
 opencensus_trace_add_link('traceId', 'spanId', ['spanId' => '1234']);
 opencensus_trace_add_link('traceId', 'spanId');
@@ -29,6 +31,7 @@ Array
             [spanId:protected] => spanId
             [options:protected] => Array
                 (
+                    [type] => CHILD_LINKED_SPAN
                 )
 
         )
@@ -39,6 +42,7 @@ Array
             [spanId:protected] => spanId
             [options:protected] => Array
                 (
+                    [spanId] => 1234
                 )
 
         )

--- a/ext/tests/message_events.phpt
+++ b/ext/tests/message_events.phpt
@@ -4,7 +4,9 @@ OpenCensus Trace: Test setting message events
 <?php
 
 opencensus_trace_begin('root', ['spanId' => '1234']);
-opencensus_trace_add_message_event('TYPE_UNSPECIFIED', 'some id');
+opencensus_trace_add_message_event('TYPE_UNSPECIFIED', 'some id', [
+    'compressedSize' => 123
+]);
 opencensus_trace_begin('inner', []);
 opencensus_trace_add_message_event('TYPE_UNSPECIFIED', 'some id', ['spanId' => '1234']);
 opencensus_trace_add_message_event('TYPE_UNSPECIFIED', 'some id');
@@ -30,6 +32,7 @@ Array
             [time:protected] => %d.%d
             [options:protected] => Array
                 (
+                    [compressedSize] => 123
                 )
 
         )
@@ -41,6 +44,7 @@ Array
             [time:protected] => %d.%d
             [options:protected] => Array
                 (
+                    [spanId] => 1234
                 )
 
         )

--- a/src/Trace/RequestHandler.php
+++ b/src/Trace/RequestHandler.php
@@ -138,11 +138,7 @@ class RequestHandler
 
         $this->scope->close();
 
-        // Fetch the SpanData of all the collected Spans
-        $spans = array_map(function (Span $span) {
-            return $span->spanData();
-        }, $this->tracer->spans());
-        $this->exporter->export($spans);
+        $this->exporter->export($this->tracer->spans());
     }
 
     /**

--- a/src/Trace/RequestHandler.php
+++ b/src/Trace/RequestHandler.php
@@ -210,6 +210,59 @@ class RequestHandler
         $this->tracer->addAttribute($attribute, $value, $options);
     }
 
+    /**
+     * Add an annotation to the provided Span
+     *
+     * @param string $description
+     * @param array $options [optional] Configuration options.
+     *
+     *      @type Span $span The span to add the annotation to.
+     *      @type array $attributes Attributes for this annotation.
+     *      @type \DateTimeInterface|int|float $time The time of this event.
+     */
+    public function addAnnotation($description, $options = [])
+    {
+        $this->tracer->addAnnotation($description, $options);
+    }
+
+    /**
+     * Add a link to the provided Span
+     *
+     * @param string $traceId
+     * @param string $spanId
+     * @param array $options [optional] Configuration options.
+     *
+     *      @type Span $span The span to add the link to.
+     *      @type string $type The relationship of the current span relative to
+     *            the linked span: child, parent, or unspecified.
+     *      @type array $attributes Attributes for this annotation.
+     *      @type \DateTimeInterface|int|float $time The time of this event.
+     */
+    public function addLink($traceId, $spanId, $options = [])
+    {
+        $this->tracer->addLink($traceId, $spanId, $options);
+    }
+
+    /**
+     * Add an message event to the provided Span
+     *
+     * @param string $type
+     * @param string $id
+     * @param array $options [optional] Configuration options.
+     *
+     *      @type Span $span The span to add the message event to.
+     *      @type int $uncompressedSize The number of uncompressed bytes sent or
+     *            received.
+     *      @type int $compressedSize The number of compressed bytes sent or
+     *            received. If missing assumed to be the same size as
+     *            uncompressed.
+     *      @type \DateTimeInterface|int|float $time The time of this event.
+     */
+    public function addMessageEvent($type, $id, $options)
+    {
+        $this->tracer->addMessageEvent($type, $id, $options);
+    }
+
     public function addCommonRequestAttributes(array $headers)
     {
         $responseCode = http_response_code();

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -152,6 +152,11 @@ class Span
     private $tracer;
 
     /**
+     * @var bool
+     */
+    private $attached = false;
+
+    /**
      * Instantiate a new Span instance.
      *
      * @param array $options [optional] Configuration options.
@@ -297,6 +302,20 @@ class Span
     }
 
     /**
+     * Attach a single attribute to this object.
+     *
+     * @param string $attribute The name of the attribute.
+     * @param mixed $value The value of the attribute. Will be cast to a string
+     */
+    public function addAttribute($attribute, $value)
+    {
+        $this->attributes[$attribute] = (string) $value;
+        if ($this->tracer) {
+            $this->tracer->addAttribute($attribute, $value, ['span' => $this]);
+        }
+    }
+
+    /**
      * Add a time event to this span.
      *
      * @param TimeEvent $timeEvent
@@ -318,9 +337,8 @@ class Span
                     'span' => $this
                 ]);
             }
-        } else {
-            $this->timeEvents[] = $timeEvent;
         }
+        $this->timeEvents[] = $timeEvent;
     }
 
     /**
@@ -348,9 +366,8 @@ class Span
                 'type' => $link->type(),
                 'span' => $this
             ]);
-        } else {
-            $this->links[] = $link;
         }
+        $this->links[] = $link;
     }
 
     /**

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -147,6 +147,11 @@ class Span
     private $kind;
 
     /**
+     * @var TracerInterface
+     */
+    private $tracer;
+
+    /**
      * Instantiate a new Span instance.
      *
      * @param array $options [optional] Configuration options.
@@ -176,7 +181,8 @@ class Span
             'parentSpanId' => null,
             'status' => null,
             'sameProcessAsParentSpan' => true,
-            'kind' => self::KIND_UNSPECIFIED
+            'kind' => self::KIND_UNSPECIFIED,
+            'tracer' => null
         ];
 
         $this->traceId = $options['traceId'];
@@ -215,6 +221,7 @@ class Span
         $this->status = $options['status'];
         $this->sameProcessAsParentSpan = $options['sameProcessAsParentSpan'];
         $this->kind = $options['kind'];
+        $this->tracer = $options['tracer'];
     }
 
     /**

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -303,7 +303,24 @@ class Span
      */
     public function addTimeEvent(TimeEvent $timeEvent)
     {
-        $this->timeEvents[] = $timeEvent;
+        if ($this->tracer) {
+            if ($timeEvent instanceof Annotation) {
+                $this->tracer->addAnnotation($timeEvent->description(), [
+                    'time' => $timeEvent->time(),
+                    'attributes' => $timeEvent->attributes(),
+                    'span' => $this
+                ]);
+            } else {
+                $this->tracer->addMessageEvent($timeEvent->type(), $timeEvent->id(), [
+                    'time' => $timeEvent->time(),
+                    'compressedSize' => $timeEvent->compressedSize(),
+                    'uncompressedSize' => $timeEvent->uncompressedSize(),
+                    'span' => $this
+                ]);
+            }
+        } else {
+            $this->timeEvents[] = $timeEvent;
+        }
     }
 
     /**
@@ -325,7 +342,15 @@ class Span
      */
     public function addLink(Link $link)
     {
-        $this->links[] = $link;
+        if ($this->tracer) {
+            $this->tracer->addLink($link->traceId(), $link->spanId(), [
+                'attributes' => $link->attributes(),
+                'type' => $link->type(),
+                'span' => $this
+            ]);
+        } else {
+            $this->links[] = $link;
+        }
     }
 
     /**

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -310,7 +310,7 @@ class Span
     public function addAttribute($attribute, $value)
     {
         $this->attributes[$attribute] = (string) $value;
-        if ($this->tracer) {
+        if ($this->attached && $this->tracer) {
             $this->tracer->addAttribute($attribute, $value, ['span' => $this]);
         }
     }
@@ -322,7 +322,7 @@ class Span
      */
     public function addTimeEvent(TimeEvent $timeEvent)
     {
-        if ($this->tracer) {
+        if ($this->attached && $this->tracer) {
             if ($timeEvent instanceof Annotation) {
                 $this->tracer->addAnnotation($timeEvent->description(), [
                     'time' => $timeEvent->time(),
@@ -360,7 +360,7 @@ class Span
      */
     public function addLink(Link $link)
     {
-        if ($this->tracer) {
+        if ($this->attached && $this->tracer) {
             $this->tracer->addLink($link->traceId(), $link->spanId(), [
                 'attributes' => $link->attributes(),
                 'type' => $link->type(),
@@ -379,6 +379,14 @@ class Span
     public function setStatus($code, $message)
     {
         $this->status = new Status($code, $message);
+    }
+
+    /**
+     * Mark this span as attached.
+     */
+    public function attach()
+    {
+        $this->attached = true;
     }
 
     /**

--- a/src/Trace/Storage/ExtensionStorage.php
+++ b/src/Trace/Storage/ExtensionStorage.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace OpenCensus\Trace\Storage;
+
+use OpenCensus\Trace\Annotation;
+use OpenCensus\Trace\DateFormatTrait;
+use OpenCensus\Trace\Link;
+use OpenCensus\Trace\MessageEvent;
+use OpenCensus\Trace\Span;
+use OpenCensus\Trace\SpanContext;
+use OpenCensus\Trace\SpanData;
+
+class ExtensionStorage implements SpanStorageInterface
+{
+    use DateFormatTrait;
+
+    private $spans = [];
+
+    public function __construct(SpanContext $initialContext = null)
+    {
+        if ($initialContext) {
+            opencensus_trace_set_context($initialContext->traceId(), $initialContext->spanId());
+        }
+    }
+
+    public function attach(Span $span)
+    {
+        $this->spans[$span->spanId()] = $span;
+
+        $spanData = $span->spanData();
+        $startTime = $spanData->startTime()
+            ? (float)($spanData->startTime()->format('U.u'))
+            : microtime(true);
+        $info = [
+            'traceId' => $spanData->traceId(),
+            'spanId' => $spanData->spanId(),
+            'parentSpanId' => $spanData->parentSpanId(),
+            'startTime' => $startTime,
+            'attributes' => $spanData->attributes(),
+            'stackTrace' => $spanData->stackTrace(),
+            'kind' => $spanData->kind(),
+            'sameProcessAsParentSpan' => $spanData->sameProcessAsParentSpan()
+        ];
+
+        opencensus_trace_begin($spanData->name(), $info);
+        foreach ($spanData->timeEvents() as $timeEvent) {
+            if ($timeEvent instanceof Annotation) {
+                $this->addAnnotation($span, $timeEvent);
+            } elseif ($timeEvent instanceof MessageEvent) {
+                $this->addMessageEvent($span, $timeEvent);
+            }
+        }
+        foreach ($spanData->links() as $link) {
+            $this->addLink($span, $link);
+        }
+
+        $this->hasSpans = true;
+    }
+
+    public function detach(Span $span)
+    {
+        opencensus_trace_finish();
+    }
+
+    public function addAttribute(Span $span, $attribute, $value)
+    {
+        if ($this->attached($span)) {
+            opencensus_trace_add_attribute($attribute, $value, [
+                'spanId' => $span->spanId()
+            ]);
+        }
+    }
+
+    public function addAnnotation(Span $span, Annotation $annotation)
+    {
+        if ($this->attached($span)) {
+            opencensus_trace_add_annotation($annotation->description(), [
+                'attributes' => $annotation->attributes(),
+                'time' => $annotation->time(),
+                'spanId' => $span->spanId()
+            ]);
+        }
+    }
+
+    public function addLink(Span $span, Link $link)
+    {
+        if ($this->attached($span)) {
+            opencensus_trace_add_link($link->traceId(), $link->spanId(), [
+                'attributes' => $link->attributes(),
+                'type' => $link->type(),
+                'spanId' => $span->spanId()
+            ]);
+        }
+    }
+
+    public function addMessageEvent(Span $span, MessageEvent $messageEvent)
+    {
+        if ($this->attached($span)) {
+            opencensus_trace_add_message_event($messageEvent->type(), $messageEvent->id(), [
+                'time' => $messageEvent->time(),
+                'compressedSize' => $messageEvent->compressedSize(),
+                'uncompressedSize' => $messageEvent->uncompressedSize(),
+                'spanId' => $span->spanId()
+            ]);
+        }
+    }
+
+    public function spans()
+    {
+        // each span returned from opencensus_trace_list should be a
+        // OpenCensus\Span object
+        $traceId = $this->spanContext()->traceId();
+        return array_map(function ($span) use ($traceId) {
+            return $this->mapSpan($span, $traceId);
+        }, opencensus_trace_list());
+    }
+
+    public function hasAttachedSpans()
+    {
+        return !empty(opencensus_trace_list());
+    }
+
+    public function spanContext()
+    {
+        $context = opencensus_trace_context();
+        return new SpanContext(
+            $context->traceId(),
+            $context->spanId(),
+            true
+        );
+    }
+
+    private function mapSpan($span, $traceId)
+    {
+        return new SpanData(
+            $span->name(),
+            $traceId,
+            $span->spanId(),
+            $this->formatFloatTimeToDate($span->startTime()),
+            $this->formatFloatTimeToDate($span->endTime()),
+            [
+                'parentSpanId' => $span->parentSpanId(),
+                'attributes' => $span->attributes(),
+                'stackTrace' => $span->stackTrace(),
+                'links' => array_map([$this, 'mapLink'], $span->links()),
+                'timeEvents' => array_map([$this, 'mapTimeEvent'], $span->timeEvents()),
+                'kind' => $this->getKind($span),
+                'sameProcessAsParentSpan' => $this->getSameProcessAsParentSpan($span)
+            ]
+        );
+    }
+
+    private function getKind($span)
+    {
+        if (method_exists($span, 'kind')) {
+            return $span->kind();
+        }
+        return Span::KIND_UNSPECIFIED;
+    }
+
+    private function getSameProcessAsParentSpan($span)
+    {
+        if (method_exists($span, 'sameProcessAsParentSpan')) {
+            return $span->sameProcessAsParentSpan();
+        }
+        return true;
+    }
+
+    private function mapLink($link)
+    {
+        return new Link($link->traceId(), $link->spanId(), $link->options());
+    }
+
+    private function mapTimeEvent($timeEvent)
+    {
+        $options = $timeEvent->options();
+        $options['time'] = $timeEvent->time();
+
+        switch (get_class($timeEvent)) {
+            case 'OpenCensus\Trace\Ext\Annotation':
+                return new Annotation($timeEvent->description(), $options);
+                break;
+            case 'OpenCensus\Trace\Ext\MessageEvent':
+                return new MessageEvent($timeEvent->type(), $timeEvent->id(), $options);
+                break;
+        }
+        return null;
+    }
+
+    private function attached(Span $span)
+    {
+        return array_key_exists($span->spanId(), $this->spans);
+    }
+}

--- a/src/Trace/Storage/MemoryStorage.php
+++ b/src/Trace/Storage/MemoryStorage.php
@@ -2,11 +2,13 @@
 
 namespace OpenCensus\Trace\Storage;
 
+use OpenCensus\Core\Context;
 use OpenCensus\Trace\Annotation;
 use OpenCensus\Trace\AttributeTrait;
 use OpenCensus\Trace\Link;
 use OpenCensus\Trace\MessageEvent;
 use OpenCensus\Trace\Span;
+use OpenCensus\Trace\SpanContext;
 
 class MemoryStorage implements SpanStorageInterface
 {

--- a/src/Trace/Storage/MemoryStorage.php
+++ b/src/Trace/Storage/MemoryStorage.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace OpenCensus\Trace\Storage;
+
+use OpenCensus\Trace\Annotation;
+use OpenCensus\Trace\AttributeTrait;
+use OpenCensus\Trace\Link;
+use OpenCensus\Trace\MessageEvent;
+use OpenCensus\Trace\Span;
+
+class MemoryStorage implements SpanStorageInterface
+{
+    /**
+     * @var Span[]
+     */
+    private $spans = [];
+
+    /**
+     * @var array Associative array of spans keyed by id.
+     */
+    private $spansById = [];
+
+    public function addAttribute(Span $span, $attribute, $value)
+    {
+        $this->spansById[$span->spanId()] = $span;
+    }
+
+    public function addAnnotation(Span $span, Annotation $annotation)
+    {
+        $this->spansById[$span->spanId()] = $span;
+    }
+
+    public function addLink(Span $span, Link $link)
+    {
+        $this->spansById[$span->spanId()] = $span;
+    }
+
+    public function addMessageEvent(Span $span, MessageEvent $messageEvent)
+    {
+        $this->spansById[$span->spanId()] = $span;
+    }
+
+    public function spanContext()
+    {
+        $context = Context::current();
+        return new SpanContext(
+            $context->value('traceId'),
+            $context->value('spanId'),
+            $context->value('enabled'),
+            $context->value('fromHeader')
+        );
+    }
+
+    public function attach(Span $span)
+    {
+        $this->spans[] = $span;
+    }
+
+    public function spans()
+    {
+        return $this->spans;
+    }
+
+    public function hasAttachedSpans()
+    {
+        return !empty($this->spans);
+    }
+}

--- a/src/Trace/Storage/SpanStorageInterface.php
+++ b/src/Trace/Storage/SpanStorageInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace OpenCensus\Trace\Storage;
+
+use OpenCensus\Trace\Annotation;
+use OpenCensus\Trace\Link;
+use OpenCensus\Trace\MessageEvent;
+use OpenCensus\Trace\Span;
+
+interface SpanStorageInterface
+{
+    public function addAttribute(Span $span, $attribute, $value);
+
+    public function addAnnotation(Span $span, Annotation $annotation);
+
+    public function addLink(Span $span, Link $link);
+
+    public function addMessageEvent(Span $span, MessageEvent $messageEvent);
+
+    public function spanContext();
+
+    public function attach(Span $span);
+
+    public function hasAttachedSpans();
+}

--- a/src/Trace/Tracer.php
+++ b/src/Trace/Tracer.php
@@ -240,6 +240,69 @@ class Tracer
     }
 
     /**
+     * Add an annotation to the provided Span
+     *
+     * @param string $description
+     * @param array $options [optional] Configuration options.
+     *
+     *      @type Span $span The span to add the annotation to.
+     *      @type array $attributes Attributes for this annotation.
+     *      @type \DateTimeInterface|int|float $time The time of this event.
+     */
+    public static function addAnnotation($description, $options = [])
+    {
+        if (!isset(self::$instance)) {
+            return;
+        }
+        return self::$instance->addAnnotation($description, $options);
+    }
+
+    /**
+     * Add a link to the provided Span
+     *
+     * @param string $traceId
+     * @param string $spanId
+     * @param array $options [optional] Configuration options.
+     *
+     *      @type Span $span The span to add the link to.
+     *      @type string $type The relationship of the current span relative to
+     *            the linked span: child, parent, or unspecified.
+     *      @type array $attributes Attributes for this annotation.
+     *      @type \DateTimeInterface|int|float $time The time of this event.
+     */
+    public static function addLink($traceId, $spanId, $options = [])
+    {
+        if (!isset(self::$instance)) {
+            return;
+        }
+        return self::$instance->addLink($traceId, $spanId, $options);
+    }
+
+    /**
+     * Add an message event to the provided Span
+     *
+     * @param string $type
+     * @param string $id
+     * @param array $options [optional] Configuration options.
+     *
+     *      @type Span $span The span to add the message event to.
+     *      @type int $uncompressedSize The number of uncompressed bytes sent or
+     *            received.
+     *      @type int $compressedSize The number of compressed bytes sent or
+     *            received. If missing assumed to be the same size as
+     *            uncompressed.
+     *      @type \DateTimeInterface|int|float $time The time of this event.
+     */
+    public static function addMessageEvent($type, $id, $options)
+    {
+        if (!isset(self::$instance)) {
+            return;
+        }
+        return self::$instance->addMessageEvent($type, $id, $options);
+    }
+
+
+    /**
      * Returns the current span context.
      *
      * @return SpanContext

--- a/src/Trace/Tracer/ContextTracer.php
+++ b/src/Trace/Tracer/ContextTracer.php
@@ -154,7 +154,7 @@ class ContextTracer implements TracerInterface
     public function addAnnotation($description, $options = [])
     {
         $span = $this->getSpan($options);
-        $span->addTimeEvent(new Annotation($description, $options = []));
+        $span->addTimeEvent(new Annotation($description, $options));
     }
 
     /**
@@ -194,7 +194,7 @@ class ContextTracer implements TracerInterface
     public function addMessageEvent($type, $id, $options = [])
     {
         $span = $this->getSpan($options);
-        $span->addTimeEvent(new MessageEvent($id, $options));
+        $span->addTimeEvent(new MessageEvent($type, $id, $options));
     }
 
     /**

--- a/src/Trace/Tracer/ContextTracer.php
+++ b/src/Trace/Tracer/ContextTracer.php
@@ -99,6 +99,7 @@ class ContextTracer implements TracerInterface
      */
     public function withSpan(Span $span)
     {
+        $span->attach();
         array_push($this->spans, $span);
         $prevContext = Context::current()
             ->withValues([

--- a/src/Trace/Tracer/ExtensionTracer.php
+++ b/src/Trace/Tracer/ExtensionTracer.php
@@ -103,6 +103,7 @@ class ExtensionTracer implements TracerInterface
             'kind' => $spanData->kind(),
             'sameProcessAsParentSpan' => $spanData->sameProcessAsParentSpan()
         ];
+        $span->attach();
         opencensus_trace_begin($spanData->name(), $info);
         foreach ($spanData->timeEvents() as $timeEvent) {
             if ($timeEvent instanceof Annotation) {

--- a/src/Trace/Tracer/ExtensionTracer.php
+++ b/src/Trace/Tracer/ExtensionTracer.php
@@ -76,6 +76,7 @@ class ExtensionTracer implements TracerInterface
         if (!array_key_exists('name', $spanOptions)) {
             $spanOption['name'] = $this->generateSpanName();
         }
+        $spanOptions['tracer'] = $this;
         return new Span($spanOptions);
     }
 

--- a/src/Trace/Tracer/TracerInterface.php
+++ b/src/Trace/Tracer/TracerInterface.php
@@ -19,6 +19,7 @@ namespace OpenCensus\Trace\Tracer;
 
 use OpenCensus\Trace\SpanContext;
 use OpenCensus\Trace\Span;
+use OpenCensus\Trace\SpanData;
 
 /**
  * This interface allows you to use the null object pattern for your tracer.
@@ -58,7 +59,7 @@ interface TracerInterface
     /**
      * Return the spans collected.
      *
-     * @return Span[]
+     * @return SpanData[]
      */
     public function spans();
 

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -130,6 +130,113 @@ class RequestHandlerTest extends TestCase
         $this->assertInstanceOf(NullTracer::class, $tracer);
     }
 
+    public function testAddsAttributes()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt) {
+            $rt->addAttribute('foo', 'bar');
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[2]->spanData();
+        $attributes = $span->attributes();
+        $this->assertCount(1, $attributes);
+        $this->assertEquals('bar', $attributes['foo']);
+    }
+
+
+    public function testAddsAttributesToSpecificSpan()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt, $outer) {
+            $rt->addAttribute('foo', 'bar', [
+                'span' => $outer
+            ]);
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[1]->spanData();
+        $attributes = $span->attributes();
+        $this->assertCount(1, $attributes);
+        $this->assertEquals('bar', $attributes['foo']);
+    }
+
+    public function testAddsAttributesToSpecificUnattachedDetachedSpan()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $outer->addAttribute('foo', 'bar');
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt) {
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[1]->spanData();
+        $attributes = $span->attributes();
+        $this->assertCount(1, $attributes);
+        $this->assertEquals('bar', $attributes['foo']);
+    }
+
+    public function testAddsAttributesToSpecificDetachedSpan()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt, $outer) {
+            $outer->addAttribute('foo', 'bar');
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[1]->spanData();
+        $attributes = $span->attributes();
+        $this->assertCount(1, $attributes);
+        $this->assertEquals('bar', $attributes['foo']);
+    }
+
     public function testAddsAnnotation()
     {
         $this->sampler->shouldSample()->willReturn(true);
@@ -182,6 +289,38 @@ class RequestHandlerTest extends TestCase
                 ],
                 'span' => $outer
             ]);
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[1]->spanData();
+        $timeEvents = $span->timeEvents();
+        $this->assertCount(1, $timeEvents);
+        $this->assertInstanceOf(Annotation::class, $timeEvents[0]);
+        $this->assertCount(1, $timeEvents[0]->attributes());
+        $this->assertEquals('bar', $timeEvents[0]->attributes()['foo']);
+    }
+
+    public function testAddsAnnotationToSpecificUnattachedDetachedSpan()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $outer->addTimeEvent(new Annotation('some message', [
+            'attributes' => [
+                'foo' => 'bar'
+            ]
+        ]));
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt) {
         });
         $scope->close();
 
@@ -298,6 +437,41 @@ class RequestHandlerTest extends TestCase
         $this->assertEquals('bar', $links[0]->attributes()['foo']);
     }
 
+    public function testAddsLinkToSpecificUnattachedDetachedSpan()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $outer->addLink(new Link('aaa', 'bbb', [
+            'type' => Link::TYPE_PARENT_LINKED_SPAN,
+            'attributes' => [
+                'foo' => 'bar'
+            ]
+        ]));
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt) {
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[1]->spanData();
+        $links = $span->links();
+        $this->assertCount(1, $links);
+        $this->assertEquals('aaa', $links[0]->traceId());
+        $this->assertEquals('bbb', $links[0]->spanId());
+        $this->assertEquals('PARENT_LINKED_SPAN', $links[0]->type());
+        $this->assertCount(1, $links[0]->attributes());
+        $this->assertEquals('bar', $links[0]->attributes()['foo']);
+    }
+
     public function testAddsLinkToSpecificDetachedSpan()
     {
         $this->sampler->shouldSample()->willReturn(true);
@@ -385,6 +559,43 @@ class RequestHandlerTest extends TestCase
                 'uncompressedSize' => 234,
                 'span' => $outer
             ]);
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[1]->spanData();
+        $timeEvents = $span->timeEvents();
+        $this->assertCount(1, $timeEvents);
+        $this->assertInstanceOf(MessageEvent::class, $timeEvents[0]);
+        $this->assertEquals('SENT', $timeEvents[0]->type());
+        $this->assertEquals('message-id', $timeEvents[0]->id());
+        $this->assertEquals(123, $timeEvents[0]->compressedSize());
+        $this->assertEquals(234, $timeEvents[0]->uncompressedSize());
+    }
+
+    public function testAddsMessageEventToSpecificUnattachedDetachedSpan()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $outer->addTimeEvent(
+            new MessageEvent(
+                MessageEvent::TYPE_SENT, 'message-id', [
+                    'compressedSize' => 123,
+                    'uncompressedSize' => 234
+                ]
+            )
+        );
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt) {
         });
         $scope->close();
 

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -22,6 +22,7 @@ use OpenCensus\Trace\Link;
 use OpenCensus\Trace\MessageEvent;
 use OpenCensus\Trace\Span;
 use OpenCensus\Trace\SpanContext;
+use OpenCensus\Trace\SpanData;
 use OpenCensus\Trace\RequestHandler;
 use OpenCensus\Trace\Exporter\ExporterInterface;
 use OpenCensus\Trace\Sampler\SamplerInterface;
@@ -64,11 +65,11 @@ class RequestHandlerTest extends TestCase
         $spans = $rt->tracer()->spans();
         $this->assertCount(2, $spans);
         foreach ($spans as $span) {
-            $this->assertInstanceOf(Span::class, $span);
-            $this->assertNotEmpty($span->spanData()->endTime());
+            $this->assertInstanceOf(SpanData::class, $span);
+            $this->assertNotEmpty($span->endTime());
         }
-        $spanData1 = $spans[0]->spanData();
-        $spanData2 = $spans[1]->spanData();
+        $spanData1 = $spans[0];
+        $spanData2 = $spans[1];
         $this->assertEquals('main', $spanData1->name());
         $this->assertEquals('inner', $spanData2->name());
         $this->assertEquals($spanData1->spanId(), $spanData2->parentSpanId());
@@ -88,7 +89,7 @@ class RequestHandlerTest extends TestCase
             ]
         );
         $span = $rt->tracer()->spans()[0];
-        $this->assertEquals('15b3', $span->spanData()->parentSpanId());
+        $this->assertEquals('15b3', $span->parentSpanId());
         $context = $rt->tracer()->spanContext();
         $this->assertEquals('12345678901234567890123456789012', $context->traceId());
     }
@@ -149,7 +150,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanAttributes = array_map(function ($span) {
-            return $span->spanData()->attributes();
+            return $span->attributes();
         }, $rt->tracer()->spans());
         $this->assertEquals([[], [], ['foo' => 'bar']], $spanAttributes);
     }
@@ -176,7 +177,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanAttributes = array_map(function ($span) {
-            return $span->spanData()->attributes();
+            return $span->attributes();
         }, $rt->tracer()->spans());
         $this->assertEquals([[], ['foo' => 'bar'], []], $spanAttributes);
     }
@@ -200,7 +201,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanAttributes = array_map(function ($span) {
-            return $span->spanData()->attributes();
+            return $span->attributes();
         }, $rt->tracer()->spans());
         $this->assertEquals([[], ['foo' => 'bar'], []], $spanAttributes);
     }
@@ -224,7 +225,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanAttributes = array_map(function ($span) {
-            return $span->spanData()->attributes();
+            return $span->attributes();
         }, $rt->tracer()->spans());
         $this->assertEquals([[], ['foo' => 'bar'], []], $spanAttributes);
     }
@@ -252,7 +253,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanTimeEvents = array_map(function ($span) {
-            return $span->spanData()->timeEvents();
+            return $span->timeEvents();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 0, 1], array_map(function ($timeEvents) {
             return count($timeEvents);
@@ -287,7 +288,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanTimeEvents = array_map(function ($span) {
-            return $span->spanData()->timeEvents();
+            return $span->timeEvents();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
             return count($timeEvents);
@@ -321,7 +322,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanTimeEvents = array_map(function ($span) {
-            return $span->spanData()->timeEvents();
+            return $span->timeEvents();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
             return count($timeEvents);
@@ -355,7 +356,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanTimeEvents = array_map(function ($span) {
-            return $span->spanData()->timeEvents();
+            return $span->timeEvents();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
             return count($timeEvents);
@@ -390,7 +391,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanLinks = array_map(function ($span) {
-            return $span->spanData()->links();
+            return $span->links();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 0, 1], array_map(function ($links) {
             return count($links);
@@ -428,7 +429,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanLinks = array_map(function ($span) {
-            return $span->spanData()->links();
+            return $span->links();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 1, 0], array_map(function ($links) {
             return count($links);
@@ -465,7 +466,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanLinks = array_map(function ($span) {
-            return $span->spanData()->links();
+            return $span->links();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 1, 0], array_map(function ($links) {
             return count($links);
@@ -502,7 +503,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanLinks = array_map(function ($span) {
-            return $span->spanData()->links();
+            return $span->links();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 1, 0], array_map(function ($links) {
             return count($links);
@@ -537,7 +538,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanTimeEvents = array_map(function ($span) {
-            return $span->spanData()->timeEvents();
+            return $span->timeEvents();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 0, 1], array_map(function ($timeEvents) {
             return count($timeEvents);
@@ -573,7 +574,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanTimeEvents = array_map(function ($span) {
-            return $span->spanData()->timeEvents();
+            return $span->timeEvents();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
             return count($timeEvents);
@@ -612,7 +613,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanTimeEvents = array_map(function ($span) {
-            return $span->spanData()->timeEvents();
+            return $span->timeEvents();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
             return count($timeEvents);
@@ -651,7 +652,7 @@ class RequestHandlerTest extends TestCase
         $scope->close();
 
         $spanTimeEvents = array_map(function ($span) {
-            return $span->spanData()->timeEvents();
+            return $span->timeEvents();
         }, $rt->tracer()->spans());
         $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
             return count($timeEvents);

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -148,12 +148,10 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[2]->spanData();
-        $attributes = $span->attributes();
-        $this->assertCount(1, $attributes);
-        $this->assertEquals('bar', $attributes['foo']);
+        $spanAttributes = array_map(function ($span) {
+            return $span->spanData()->attributes();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([[], [], ['foo' => 'bar']], $spanAttributes);
     }
 
 
@@ -177,12 +175,10 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $attributes = $span->attributes();
-        $this->assertCount(1, $attributes);
-        $this->assertEquals('bar', $attributes['foo']);
+        $spanAttributes = array_map(function ($span) {
+            return $span->spanData()->attributes();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([[], ['foo' => 'bar'], []], $spanAttributes);
     }
 
     public function testAddsAttributesToSpecificUnattachedDetachedSpan()
@@ -203,12 +199,10 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $attributes = $span->attributes();
-        $this->assertCount(1, $attributes);
-        $this->assertEquals('bar', $attributes['foo']);
+        $spanAttributes = array_map(function ($span) {
+            return $span->spanData()->attributes();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([[], ['foo' => 'bar'], []], $spanAttributes);
     }
 
     public function testAddsAttributesToSpecificDetachedSpan()
@@ -229,12 +223,10 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $attributes = $span->attributes();
-        $this->assertCount(1, $attributes);
-        $this->assertEquals('bar', $attributes['foo']);
+        $spanAttributes = array_map(function ($span) {
+            return $span->spanData()->attributes();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([[], ['foo' => 'bar'], []], $spanAttributes);
     }
 
     public function testAddsAnnotation()
@@ -259,14 +251,16 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[2]->spanData();
-        $timeEvents = $span->timeEvents();
-        $this->assertCount(1, $timeEvents);
-        $this->assertInstanceOf(Annotation::class, $timeEvents[0]);
-        $this->assertCount(1, $timeEvents[0]->attributes());
-        $this->assertEquals('bar', $timeEvents[0]->attributes()['foo']);
+        $spanTimeEvents = array_map(function ($span) {
+            return $span->spanData()->timeEvents();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 0, 1], array_map(function ($timeEvents) {
+            return count($timeEvents);
+        }, $spanTimeEvents));
+        $annotation = $spanTimeEvents[2][0];
+        $this->assertInstanceOf(Annotation::class, $annotation);
+        $this->assertCount(1, $annotation->attributes());
+        $this->assertEquals('bar', $annotation->attributes()['foo']);
     }
 
     public function testAddsAnnotationToSpecificSpan()
@@ -292,14 +286,16 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $timeEvents = $span->timeEvents();
-        $this->assertCount(1, $timeEvents);
-        $this->assertInstanceOf(Annotation::class, $timeEvents[0]);
-        $this->assertCount(1, $timeEvents[0]->attributes());
-        $this->assertEquals('bar', $timeEvents[0]->attributes()['foo']);
+        $spanTimeEvents = array_map(function ($span) {
+            return $span->spanData()->timeEvents();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
+            return count($timeEvents);
+        }, $spanTimeEvents));
+        $annotation = $spanTimeEvents[1][0];
+        $this->assertInstanceOf(Annotation::class, $annotation);
+        $this->assertCount(1, $annotation->attributes());
+        $this->assertEquals('bar', $annotation->attributes()['foo']);
     }
 
     public function testAddsAnnotationToSpecificUnattachedDetachedSpan()
@@ -324,14 +320,16 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $timeEvents = $span->timeEvents();
-        $this->assertCount(1, $timeEvents);
-        $this->assertInstanceOf(Annotation::class, $timeEvents[0]);
-        $this->assertCount(1, $timeEvents[0]->attributes());
-        $this->assertEquals('bar', $timeEvents[0]->attributes()['foo']);
+        $spanTimeEvents = array_map(function ($span) {
+            return $span->spanData()->timeEvents();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
+            return count($timeEvents);
+        }, $spanTimeEvents));
+        $annotation = $spanTimeEvents[1][0];
+        $this->assertInstanceOf(Annotation::class, $annotation);
+        $this->assertCount(1, $annotation->attributes());
+        $this->assertEquals('bar', $annotation->attributes()['foo']);
     }
 
     public function testAddsAnnotationToSpecificDetachedSpan()
@@ -356,14 +354,16 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $timeEvents = $span->timeEvents();
-        $this->assertCount(1, $timeEvents);
-        $this->assertInstanceOf(Annotation::class, $timeEvents[0]);
-        $this->assertCount(1, $timeEvents[0]->attributes());
-        $this->assertEquals('bar', $timeEvents[0]->attributes()['foo']);
+        $spanTimeEvents = array_map(function ($span) {
+            return $span->spanData()->timeEvents();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
+            return count($timeEvents);
+        }, $spanTimeEvents));
+        $annotation = $spanTimeEvents[1][0];
+        $this->assertInstanceOf(Annotation::class, $annotation);
+        $this->assertCount(1, $annotation->attributes());
+        $this->assertEquals('bar', $annotation->attributes()['foo']);
     }
 
     public function testAddsLink()
@@ -389,11 +389,13 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[2]->spanData();
-        $links = $span->links();
-        $this->assertCount(1, $links);
+        $spanLinks = array_map(function ($span) {
+            return $span->spanData()->links();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 0, 1], array_map(function ($links) {
+            return count($links);
+        }, $spanLinks));
+        $links = $spanLinks[2];
         $this->assertEquals('aaa', $links[0]->traceId());
         $this->assertEquals('bbb', $links[0]->spanId());
         $this->assertEquals('PARENT_LINKED_SPAN', $links[0]->type());
@@ -425,11 +427,13 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $links = $span->links();
-        $this->assertCount(1, $links);
+        $spanLinks = array_map(function ($span) {
+            return $span->spanData()->links();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 1, 0], array_map(function ($links) {
+            return count($links);
+        }, $spanLinks));
+        $links = $spanLinks[1];
         $this->assertEquals('aaa', $links[0]->traceId());
         $this->assertEquals('bbb', $links[0]->spanId());
         $this->assertEquals('PARENT_LINKED_SPAN', $links[0]->type());
@@ -460,11 +464,13 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $links = $span->links();
-        $this->assertCount(1, $links);
+        $spanLinks = array_map(function ($span) {
+            return $span->spanData()->links();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 1, 0], array_map(function ($links) {
+            return count($links);
+        }, $spanLinks));
+        $links = $spanLinks[1];
         $this->assertEquals('aaa', $links[0]->traceId());
         $this->assertEquals('bbb', $links[0]->spanId());
         $this->assertEquals('PARENT_LINKED_SPAN', $links[0]->type());
@@ -495,11 +501,13 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $links = $span->links();
-        $this->assertCount(1, $links);
+        $spanLinks = array_map(function ($span) {
+            return $span->spanData()->links();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 1, 0], array_map(function ($links) {
+            return count($links);
+        }, $spanLinks));
+        $links = $spanLinks[1];
         $this->assertEquals('aaa', $links[0]->traceId());
         $this->assertEquals('bbb', $links[0]->spanId());
         $this->assertEquals('PARENT_LINKED_SPAN', $links[0]->type());
@@ -528,16 +536,18 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[2]->spanData();
-        $timeEvents = $span->timeEvents();
-        $this->assertCount(1, $timeEvents);
-        $this->assertInstanceOf(MessageEvent::class, $timeEvents[0]);
-        $this->assertEquals('SENT', $timeEvents[0]->type());
-        $this->assertEquals('message-id', $timeEvents[0]->id());
-        $this->assertEquals(123, $timeEvents[0]->compressedSize());
-        $this->assertEquals(234, $timeEvents[0]->uncompressedSize());
+        $spanTimeEvents = array_map(function ($span) {
+            return $span->spanData()->timeEvents();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 0, 1], array_map(function ($timeEvents) {
+            return count($timeEvents);
+        }, $spanTimeEvents));
+        $messageEvent = $spanTimeEvents[2][0];
+        $this->assertInstanceOf(MessageEvent::class, $messageEvent);
+        $this->assertEquals('SENT', $messageEvent->type());
+        $this->assertEquals('message-id', $messageEvent->id());
+        $this->assertEquals(123, $messageEvent->compressedSize());
+        $this->assertEquals(234, $messageEvent->uncompressedSize());
     }
 
     public function testAddsMessageEventToSpecificSpan()
@@ -562,16 +572,18 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $timeEvents = $span->timeEvents();
-        $this->assertCount(1, $timeEvents);
-        $this->assertInstanceOf(MessageEvent::class, $timeEvents[0]);
-        $this->assertEquals('SENT', $timeEvents[0]->type());
-        $this->assertEquals('message-id', $timeEvents[0]->id());
-        $this->assertEquals(123, $timeEvents[0]->compressedSize());
-        $this->assertEquals(234, $timeEvents[0]->uncompressedSize());
+        $spanTimeEvents = array_map(function ($span) {
+            return $span->spanData()->timeEvents();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
+            return count($timeEvents);
+        }, $spanTimeEvents));
+        $messageEvent = $spanTimeEvents[1][0];
+        $this->assertInstanceOf(MessageEvent::class, $messageEvent);
+        $this->assertEquals('SENT', $messageEvent->type());
+        $this->assertEquals('message-id', $messageEvent->id());
+        $this->assertEquals(123, $messageEvent->compressedSize());
+        $this->assertEquals(234, $messageEvent->uncompressedSize());
     }
 
     public function testAddsMessageEventToSpecificUnattachedDetachedSpan()
@@ -599,16 +611,18 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $timeEvents = $span->timeEvents();
-        $this->assertCount(1, $timeEvents);
-        $this->assertInstanceOf(MessageEvent::class, $timeEvents[0]);
-        $this->assertEquals('SENT', $timeEvents[0]->type());
-        $this->assertEquals('message-id', $timeEvents[0]->id());
-        $this->assertEquals(123, $timeEvents[0]->compressedSize());
-        $this->assertEquals(234, $timeEvents[0]->uncompressedSize());
+        $spanTimeEvents = array_map(function ($span) {
+            return $span->spanData()->timeEvents();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
+            return count($timeEvents);
+        }, $spanTimeEvents));
+        $messageEvent = $spanTimeEvents[1][0];
+        $this->assertInstanceOf(MessageEvent::class, $messageEvent);
+        $this->assertEquals('SENT', $messageEvent->type());
+        $this->assertEquals('message-id', $messageEvent->id());
+        $this->assertEquals(123, $messageEvent->compressedSize());
+        $this->assertEquals(234, $messageEvent->uncompressedSize());
     }
 
     public function testAddsMessageEventToSpecificDetachedSpan()
@@ -636,15 +650,17 @@ class RequestHandlerTest extends TestCase
         });
         $scope->close();
 
-        $spans = $rt->tracer()->spans();
-        $this->assertCount(3, $spans);
-        $span = $spans[1]->spanData();
-        $timeEvents = $span->timeEvents();
-        $this->assertCount(1, $timeEvents);
-        $this->assertInstanceOf(MessageEvent::class, $timeEvents[0]);
-        $this->assertEquals('SENT', $timeEvents[0]->type());
-        $this->assertEquals('message-id', $timeEvents[0]->id());
-        $this->assertEquals(123, $timeEvents[0]->compressedSize());
-        $this->assertEquals(234, $timeEvents[0]->uncompressedSize());
+        $spanTimeEvents = array_map(function ($span) {
+            return $span->spanData()->timeEvents();
+        }, $rt->tracer()->spans());
+        $this->assertEquals([0, 1, 0], array_map(function ($timeEvents) {
+            return count($timeEvents);
+        }, $spanTimeEvents));
+        $messageEvent = $spanTimeEvents[1][0];
+        $this->assertInstanceOf(MessageEvent::class, $messageEvent);
+        $this->assertEquals('SENT', $messageEvent->type());
+        $this->assertEquals('message-id', $messageEvent->id());
+        $this->assertEquals(123, $messageEvent->compressedSize());
+        $this->assertEquals(234, $messageEvent->uncompressedSize());
     }
 }

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -130,9 +130,6 @@ class RequestHandlerTest extends TestCase
         $this->assertInstanceOf(NullTracer::class, $tracer);
     }
 
-    /**
-     * @group focus
-     */
     public function testAddsAnnotation()
     {
         $this->sampler->shouldSample()->willReturn(true);

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -17,6 +17,9 @@
 
 namespace OpenCensus\Tests\Unit\Trace;
 
+use OpenCensus\Trace\Annotation;
+use OpenCensus\Trace\Link;
+use OpenCensus\Trace\MessageEvent;
 use OpenCensus\Trace\Span;
 use OpenCensus\Trace\SpanContext;
 use OpenCensus\Trace\RequestHandler;
@@ -125,5 +128,211 @@ class RequestHandlerTest extends TestCase
 
         $this->assertFalse($tracer->enabled());
         $this->assertInstanceOf(NullTracer::class, $tracer);
+    }
+
+    /**
+     * @group focus
+     */
+    public function testAddsAnnotation()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt) {
+            $rt->addAnnotation('some message', [
+                'attributes' => [
+                    'foo' => 'bar'
+                ]
+            ]);
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[2]->spanData();
+        $timeEvents = $span->timeEvents();
+        $this->assertCount(1, $timeEvents);
+        $this->assertInstanceOf(Annotation::class, $timeEvents[0]);
+        $this->assertCount(1, $timeEvents[0]->attributes());
+        $this->assertEquals('bar', $timeEvents[0]->attributes()['foo']);
+    }
+
+    public function testAddsAnnotationToSpecificSpan()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt, $outer) {
+            $rt->addAnnotation('some message', [
+                'attributes' => [
+                    'foo' => 'bar'
+                ],
+                'span' => $outer
+            ]);
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[1]->spanData();
+        $timeEvents = $span->timeEvents();
+        $this->assertCount(1, $timeEvents);
+        $this->assertInstanceOf(Annotation::class, $timeEvents[0]);
+        $this->assertCount(1, $timeEvents[0]->attributes());
+        $this->assertEquals('bar', $timeEvents[0]->attributes()['foo']);
+    }
+
+    public function testAddsLink()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt) {
+            $rt->addLink('aaa', 'bbb', [
+                'type' => Link::TYPE_PARENT_LINKED_SPAN,
+                'attributes' => [
+                    'foo' => 'bar'
+                ]
+            ]);
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[2]->spanData();
+        $links = $span->links();
+        $this->assertCount(1, $links);
+        $this->assertEquals('aaa', $links[0]->traceId());
+        $this->assertEquals('bbb', $links[0]->spanId());
+        $this->assertEquals('PARENT_LINKED_SPAN', $links[0]->type());
+        $this->assertCount(1, $links[0]->attributes());
+        $this->assertEquals('bar', $links[0]->attributes()['foo']);
+    }
+
+    public function testAddsLinkToSpecificSpan()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt, $outer) {
+            $rt->addLink('aaa', 'bbb', [
+                'type' => Link::TYPE_PARENT_LINKED_SPAN,
+                'attributes' => [
+                    'foo' => 'bar'
+                ],
+                'span' => $outer
+            ]);
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[1]->spanData();
+        $links = $span->links();
+        $this->assertCount(1, $links);
+        $this->assertEquals('aaa', $links[0]->traceId());
+        $this->assertEquals('bbb', $links[0]->spanId());
+        $this->assertEquals('PARENT_LINKED_SPAN', $links[0]->type());
+        $this->assertCount(1, $links[0]->attributes());
+        $this->assertEquals('bar', $links[0]->attributes()['foo']);
+    }
+
+    public function testAddsMessageEvent()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt) {
+            $rt->addMessageEvent(MessageEvent::TYPE_SENT, 'message-id', [
+                'compressedSize' => 123,
+                'uncompressedSize' => 234
+            ]);
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[2]->spanData();
+        $timeEvents = $span->timeEvents();
+        $this->assertCount(1, $timeEvents);
+        $this->assertInstanceOf(MessageEvent::class, $timeEvents[0]);
+        $this->assertEquals('SENT', $timeEvents[0]->type());
+        $this->assertEquals('message-id', $timeEvents[0]->id());
+        $this->assertEquals(123, $timeEvents[0]->compressedSize());
+        $this->assertEquals(234, $timeEvents[0]->uncompressedSize());
+    }
+
+    public function testAddsMessageEventToSpecificSpan()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        $outer = $rt->startSpan(['name' => 'outer']);
+        $scope = $rt->withSpan($outer);
+        $rt->inSpan(['name' => 'inner'], function () use ($rt, $outer) {
+            $rt->addMessageEvent(MessageEvent::TYPE_SENT, 'message-id', [
+                'compressedSize' => 123,
+                'uncompressedSize' => 234,
+                'span' => $outer
+            ]);
+        });
+        $scope->close();
+
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(3, $spans);
+        $span = $spans[1]->spanData();
+        $timeEvents = $span->timeEvents();
+        $this->assertCount(1, $timeEvents);
+        $this->assertInstanceOf(MessageEvent::class, $timeEvents[0]);
+        $this->assertEquals('SENT', $timeEvents[0]->type());
+        $this->assertEquals('message-id', $timeEvents[0]->id());
+        $this->assertEquals(123, $timeEvents[0]->compressedSize());
+        $this->assertEquals(234, $timeEvents[0]->uncompressedSize());
     }
 }

--- a/tests/unit/Trace/Tracer/AbstractTracerTest.php
+++ b/tests/unit/Trace/Tracer/AbstractTracerTest.php
@@ -47,7 +47,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
         $this->assertEquals('traceid', $spanData->traceId());
         $this->assertEquals('test', $spanData->name());
         $this->assertEquals($parentSpanId, $spanData->parentSpanId());
@@ -65,7 +65,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $spanData = $spans[1]->spanData();
+        $spanData = $spans[1];
         $this->assertEquals('inner', $spanData->name());
         $attributes = $spanData->attributes();
         $this->assertArrayHasKey('foo', $attributes);
@@ -85,7 +85,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
         $this->assertEquals('root', $spanData->name());
         $attributes = $spanData->attributes();
         $this->assertArrayHasKey('foo', $attributes);
@@ -97,7 +97,7 @@ abstract class AbstractTracerTest extends TestCase
         $class = $this->getTracerClass();
         $tracer = new $class();
         $tracer->inSpan(['name' => 'test'], function () {});
-        $spanData = $tracer->spans()[0]->spanData();;
+        $spanData = $tracer->spans()[0];
         $stackframe = $spanData->stackTrace()[0];
         $this->assertEquals('testPersistsBacktrace', $stackframe['function']);
         $this->assertEquals(self::class, $stackframe['class']);
@@ -128,7 +128,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $this->assertEquivalentTimestamps(
             $span->spanData()->startTime(),
-            $tracer->spans()[0]->spanData()->startTime()
+            $tracer->spans()[0]->startTime()
         );
     }
 
@@ -144,9 +144,9 @@ abstract class AbstractTracerTest extends TestCase
         });
 
         $spans = $tracer->spans();
-        $rootSpanData = $spans[0]->spanData();
+        $rootSpanData = $spans[0];
         $this->assertCount(1, $rootSpanData->timeEvents());
-        $innerSpanData = $spans[1]->spanData();
+        $innerSpanData = $spans[1];
         $this->assertCount(1, $innerSpanData->timeEvents());
     }
 
@@ -167,7 +167,7 @@ abstract class AbstractTracerTest extends TestCase
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
 
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
         $this->assertEquals('root', $spanData->name());
         $this->assertCount(1, $spanData->timeEvents());
     }
@@ -184,9 +184,9 @@ abstract class AbstractTracerTest extends TestCase
         });
 
         $spans = $tracer->spans();
-        $rootSpanData = $spans[0]->spanData();
+        $rootSpanData = $spans[0];
         $this->assertCount(1, $rootSpanData->links());
-        $innerSpanData = $spans[1]->spanData();
+        $innerSpanData = $spans[1];
         $this->assertCount(1, $innerSpanData->links());
     }
 
@@ -205,7 +205,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
 
         $this->assertEquals('root', $spanData->name());
         $this->assertCount(1, $spanData->links());
@@ -223,9 +223,9 @@ abstract class AbstractTracerTest extends TestCase
         });
 
         $spans = $tracer->spans();
-        $rootSpanData = $spans[0]->spanData();
+        $rootSpanData = $spans[0];
         $this->assertCount(1, $rootSpanData->timeEvents());
-        $innerSpanData = $spans[1]->spanData();
+        $innerSpanData = $spans[1];
         $this->assertCount(1, $innerSpanData->timeEvents());
     }
 
@@ -244,7 +244,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
 
         $this->assertEquals('root', $spanData->name());
         $this->assertCount(1, $spanData->timeEvents());
@@ -260,7 +260,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
 
         // #131 - Span should be initialized with current time, not the epoch.
         $this->assertNotEquals(0, $spanData->startTime()->getTimestamp());
@@ -276,7 +276,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
 
         $this->assertInternalType('array', $spanData->stackTrace());
         $this->assertNotEmpty($spanData->stackTrace());
@@ -292,7 +292,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
 
         $this->assertInternalType('array', $spanData->attributes());
         $this->assertEmpty($spanData->attributes());
@@ -308,7 +308,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
 
         $this->assertInternalType('array', $spanData->links());
         $this->assertEmpty($spanData->links());
@@ -324,7 +324,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
 
         $this->assertInternalType('array', $spanData->timeEvents());
         $this->assertEmpty($spanData->timeEvents());
@@ -340,7 +340,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
 
         $this->assertEquals(Span::KIND_UNSPECIFIED, $spanData->kind());
     }
@@ -355,7 +355,7 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(1, $spans);
-        $spanData = $spans[0]->spanData();
+        $spanData = $spans[0];
 
         $this->assertEquals(Span::KIND_SERVER, $spanData->kind());
     }
@@ -372,8 +372,8 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $this->assertFalse($spans[0]->spanData()->sameProcessAsParentSpan());
-        $this->assertTrue($spans[1]->spanData()->sameProcessAsParentSpan());
+        $this->assertFalse($spans[0]->sameProcessAsParentSpan());
+        $this->assertTrue($spans[1]->sameProcessAsParentSpan());
     }
 
     public function testSameProcessAsParentSpan()
@@ -388,8 +388,8 @@ abstract class AbstractTracerTest extends TestCase
 
         $spans = $tracer->spans();
         $this->assertCount(2, $spans);
-        $this->assertTrue($spans[0]->spanData()->sameProcessAsParentSpan());
-        $this->assertFalse($spans[1]->spanData()->sameProcessAsParentSpan());
+        $this->assertTrue($spans[0]->sameProcessAsParentSpan());
+        $this->assertFalse($spans[1]->sameProcessAsParentSpan());
     }
 
     private function assertEquivalentTimestamps($expected, $value)


### PR DESCRIPTION
Data model supported these types and you could provide them when creating a span. This allows you to add time events and links to any detached span or the span currently in context.

Usage would be something like this:

```php
Tracer::inSpan(['name' => 'some process', function () {
    Tracer::addAnnotation('starting request');
    // do something
    Tracer::addAnnotation('in between');
    // do something else
    Tracer::addAnnotation('finished');
});
```