### PR TITLE
Build versioned docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ script:
   - pushd docs
   - hugo
   - popd
-  - php sami.phar update config/sami.php
+  - cp config/sami.php config/sami-config.php
+  - php sami.phar update config/sami-config.php
   - touch docs/.nojekyll
 
 branches:

--- a/README.md
+++ b/README.md
@@ -155,21 +155,21 @@ Apache 2.0 - See [LICENSE](LICENSE) for more information.
 This is not an official Google product.
 
 [census-org]: https://github.com/census-instrumentation
-[api-docs]: https://census-instrumentation.github.io/opencensus-php/api/master/
-[integration-docs]: https://census-instrumentation.github.io/opencensus-php
+[api-docs]: https://opencensus.io/api/php/api/master/
+[integration-docs]: https://opencensus.io/api/php
 [composer]: https://getcomposer.org/
 [pecl]: https://pecl.php.net/
-[never-sampler]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
-[always-sampler]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
-[multi-sampler]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Sampler/MultiSampler.html
-[qps-sampler]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
-[probability-sampler]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
-[echo-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/EchoExporter.html
-[file-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/FileExporter.html
+[never-sampler]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
+[always-sampler]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
+[multi-sampler]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Sampler/MultiSampler.html
+[qps-sampler]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
+[probability-sampler]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
+[echo-exporter]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Exporter/EchoExporter.html
+[file-exporter]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Exporter/FileExporter.html
 [jaeger-exporter]: https://github.com/census-instrumentation/opencensus-php-exporter-jaeger/blob/master/src/JaegerExporter.php
 [jaeger-packagist]: https://packagist.org/packages/opencensus/opencensus-exporter-jaeger
-[logger-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/LoggerExporter.html
-[null-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/NullExporter.html
-[stackdriver-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/StackdriverExporter.html
-[zipkin-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/ZipkinExporter.html
+[logger-exporter]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Exporter/LoggerExporter.html
+[null-exporter]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Exporter/NullExporter.html
+[stackdriver-exporter]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Exporter/StackdriverExporter.html
+[zipkin-exporter]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Exporter/ZipkinExporter.html
 [semver]: http://semver.org/

--- a/README.md
+++ b/README.md
@@ -155,21 +155,21 @@ Apache 2.0 - See [LICENSE](LICENSE) for more information.
 This is not an official Google product.
 
 [census-org]: https://github.com/census-instrumentation
-[api-docs]: https://census-instrumentation.github.io/opencensus-php/api
+[api-docs]: https://census-instrumentation.github.io/opencensus-php/api/master/
 [integration-docs]: https://census-instrumentation.github.io/opencensus-php
 [composer]: https://getcomposer.org/
 [pecl]: https://pecl.php.net/
-[never-sampler]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Sampler/NeverSampleSampler.html
-[always-sampler]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Sampler/NeverSampleSampler.html
-[multi-sampler]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Sampler/MultiSampler.html
-[qps-sampler]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Sampler/NeverSampleSampler.html
-[probability-sampler]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Sampler/NeverSampleSampler.html
-[echo-exporter]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Exporter/EchoExporter.html
-[file-exporter]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Exporter/FileExporter.html
+[never-sampler]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
+[always-sampler]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
+[multi-sampler]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Sampler/MultiSampler.html
+[qps-sampler]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
+[probability-sampler]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
+[echo-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/EchoExporter.html
+[file-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/FileExporter.html
 [jaeger-exporter]: https://github.com/census-instrumentation/opencensus-php-exporter-jaeger/blob/master/src/JaegerExporter.php
 [jaeger-packagist]: https://packagist.org/packages/opencensus/opencensus-exporter-jaeger
-[logger-exporter]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Exporter/LoggerExporter.html
-[null-exporter]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Exporter/NullExporter.html
-[stackdriver-exporter]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Exporter/StackdriverExporter.html
-[zipkin-exporter]: https://census-instrumentation.github.io/opencensus-php/api/OpenCensus/Trace/Exporter/ZipkinExporter.html
+[logger-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/LoggerExporter.html
+[null-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/NullExporter.html
+[stackdriver-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/StackdriverExporter.html
+[zipkin-exporter]: https://census-instrumentation.github.io/opencensus-php/api/master/OpenCensus/Trace/Exporter/ZipkinExporter.html
 [semver]: http://semver.org/

--- a/config/sami.php
+++ b/config/sami.php
@@ -16,7 +16,7 @@
  */
 
 use Sami\Sami;
-// use Sami\Version\GitVersionCollection;
+use Sami\Version\GitVersionCollection;
 use Symfony\Component\Finder\Finder;
 use Sami\Parser\Filter\FilterInterface;
 use Sami\Reflection\ClassReflection;
@@ -30,14 +30,15 @@ $iterator = Finder::create()
     ->name('*.php')
     ->in(__DIR__ . '/../src');
 
-// $versions = GitVersionCollection::create($root_dir)
-//     ->addFromTags('v0.*')
-//     ->add('master', 'master branch');
+$versions = GitVersionCollection::create($root_dir)
+    ->addFromTags('v0.*')
+    ->add('master', 'master branch');
 
 $sami = new Sami($iterator, [
-    // 'versions'  => $versions,
-    'build_dir' => __DIR__ . '/../docs/public/api',
-    'title' => 'OpenCensus PHP API'
+    'versions'  => $versions,
+    'build_dir' => __DIR__ . '/../docs/public/api/%version%/',
+    'title' => 'OpenCensus PHP API',
+    'cache_dir' => __DIR__ . '/../cache/%version%/'
 ]);
 
 class VisibleFilter implements FilterInterface

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://census-instrumentation.github.io/opencensus-php/"
+baseURL = "https://opencensus.io/api/php/"
 languageCode = "en-us"
 title = "OpenCensus for PHP"
 theme = "hyde"


### PR DESCRIPTION
Builds PHP class documentation for each tagged release and master. The generated documentation has a dropdown menu to switch between versions.

~Note, don't merge this until we move the documentation hosting location.~ 
Edit: Docs will be published to https://opencensus.io/api/php/ when the [opencensus-website repo](https://github.com/census-instrumentation/opencensus-website) is deployed.