### PR TITLE
Add OneLineEchoExporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The provided exporters are:
 | Class | Description | Dependency |
 | ----- | ----------- | ---------- |
 | [EchoExporter][echo-exporter] | Output the collected spans to stdout | |
+| [OneLineEchoExporter][one-line-echo-exporter] | Output the collected spans to stdout with one-line | |
 | [FileExporter][file-exporter] | Output JSON encoded spans to a file | |
 | [JaegerExporter][jaeger-exporter] | Report traces to Jaeger server via Thrift over UDP | [opencensus/opencensus-exporter-jaeger][jaeger-packagist] |
 | [LoggerExporter][logger-exporter] | Exporter JSON encoded spans to a PSR-3 logger | |
@@ -165,6 +166,7 @@ This is not an official Google product.
 [qps-sampler]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
 [probability-sampler]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Sampler/NeverSampleSampler.html
 [echo-exporter]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Exporter/EchoExporter.html
+[one-line-echo-exporter]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Exporter/OneLineEchoExporter.html
 [file-exporter]: https://opencensus.io/api/php/api/master/OpenCensus/Trace/Exporter/FileExporter.html
 [jaeger-exporter]: https://github.com/census-instrumentation/opencensus-php-exporter-jaeger/blob/master/src/JaegerExporter.php
 [jaeger-packagist]: https://packagist.org/packages/opencensus/opencensus-exporter-jaeger

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ The provided exporters are:
 | Class | Description | Dependency |
 | ----- | ----------- | ---------- |
 | [EchoExporter][echo-exporter] | Output the collected spans to stdout | |
-| [OneLineEchoExporter][one-line-echo-exporter] | Output the collected spans to stdout with one-line | |
 | [FileExporter][file-exporter] | Output JSON encoded spans to a file | |
 | [JaegerExporter][jaeger-exporter] | Report traces to Jaeger server via Thrift over UDP | [opencensus/opencensus-exporter-jaeger][jaeger-packagist] |
 | [LoggerExporter][logger-exporter] | Exporter JSON encoded spans to a PSR-3 logger | |
 | [NullExporter][null-exporter] | No-op | |
+| [OneLineEchoExporter][one-line-echo-exporter] | Output the collected spans to stdout with one-line | |
 | [StackdriverExporter][stackdriver-exporter] | Report traces to Google Cloud Stackdriver Trace | |
 | [ZipkinExporter][zipkin-exporter] | Report collected spans to a Zipkin server | |
 

--- a/src/Trace/Exporter/OneLineEchoExporter.php
+++ b/src/Trace/Exporter/OneLineEchoExporter.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright 2017 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace\Exporter;
+
+use OpenCensus\Trace\SpanData;
+
+class OneLineEchoExporter implements ExporterInterface
+{
+
+    /**
+     * Report the provided Trace to a backend.
+     *
+     * @param SpanData[] $spans
+     * @return bool
+     */
+    public function export(array $spans)
+    {
+        foreach ($spans as $span) {
+            $time = (float) ($span->endTime()->format('U.u')) - (float) ($span->startTime()->format('U.u'));
+            printf("[ %8.2f ms] %s%s", $time * 1000, $span->name(), PHP_EOL);
+            foreach ($span->attributes() as $key => $value) {
+                printf("  [%s] %s%s", $key, $value, PHP_EOL);
+            }
+        }
+        return true;
+    }
+}

--- a/src/Trace/Exporter/OneLineEchoExporter.php
+++ b/src/Trace/Exporter/OneLineEchoExporter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 OpenCensus Authors
+ * Copyright 2018 OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/Trace/Exporter/OneLineEchoExporterTest.php
+++ b/tests/unit/Trace/Exporter/OneLineEchoExporterTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2017 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Unit\Trace\Exporter;
+
+use OpenCensus\Trace\Exporter\OneLineEchoExporter;
+use OpenCensus\Trace\Span;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group trace
+ */
+class OneLineEchoExporterTest extends TestCase
+{
+    public function testLogsTrace()
+    {
+        $span = new Span([
+            'name' => 'span',
+            'startTime' => microtime(true),
+            'endTime' => microtime(true) + 10
+        ]);
+
+        ob_start();
+        $exporter = new OneLineEchoExporter();
+        $this->assertTrue($exporter->export([$span->spanData()]));
+        $output = ob_get_contents();
+        ob_end_clean();
+        $this->assertEquals('[ 10000.00 ms] span' . PHP_EOL, $output);
+    }
+}

--- a/tests/unit/Trace/Exporter/OneLineEchoExporterTest.php
+++ b/tests/unit/Trace/Exporter/OneLineEchoExporterTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 OpenCensus Authors
+ * Copyright 2018 OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,11 @@ class OneLineEchoExporterTest extends TestCase
 {
     public function testLogsTrace()
     {
+        $startTime = microtime(true);
         $span = new Span([
             'name' => 'span',
-            'startTime' => microtime(true),
-            'endTime' => microtime(true) + 10
+            'startTime' => $startTime,
+            'endTime' => $startTime + 10
         ]);
 
         ob_start();


### PR DESCRIPTION
Ref https://github.com/GoogleCloudPlatform/google-cloud-php/issues/1009#issuecomment-380953918

Add simple one-line exporter like this:

```
[    28.15 ms] /spanner-test/issues.php
  [authCache] Google\Auth\Cache\SysVCacheItemPool
  [sessionPoolCache] Google\Auth\Cache\SysVCacheItemPool
  [minSessions] 5
  [maxSessions] 100
[     0.22 ms] warmup sessions (min: 5)
  [new created sessions] 0
[    12.05 ms] ---------------------------- SELECT 1
[     1.75 ms] Google\Cloud\Spanner\Connection\Grpc::createTransactionSelector
[     4.50 ms] Google\Cloud\Spanner\Connection\Grpc::send
[     4.48 ms] Google\Cloud\Core\GrpcRequestWrapper::send
  [args] executeStreamingSql
[     4.43 ms] Google\Cloud\Spanner\V1\Gapic\SpannerGapicClient::executeStreamingSql
[     3.44 ms] Google\Cloud\Spanner\V1\ExecuteSqlRequest::__construct
[     3.41 ms] GPBMetadata\Google\Spanner\V1\Spanner::initOnce
```