### PR TITLE
Add comment header to AUTHORS file about looking at revision history

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,6 @@
+# This is the list of OpenCensus authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
 Google Inc.


### PR DESCRIPTION
This is to clarify how we manage the AUTHORS file. From OSPO: "it is sufficient to add copyright holders when they request to be added"