### PR TITLE
Add Integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,76 @@ jobs:
       RUN_EXTENSION_TESTS: 1
       SUDO_CMD: ""
 
+  integration:
+    docker:
+      - image: circleci/php:7.2-node
+      - image: memcached
+      - image: mysql:5.7
+        environment:
+          MYSQL_USER: mysql
+          MYSQL_PASSWORD: mysql
+          MYSQL_DATABASE: mysqldb
+          MYSQL_RANDOM_ROOT_PASSWORD: yes
+    steps:
+      - checkout
+      - run:
+          name: Install build tools
+          command: |
+            sudo apt-get update -y
+            sudo apt-get install -y -q --no-install-recommends \
+              build-essential \
+              g++ \
+              gcc \
+              libc-dev \
+              make \
+              autoconf \
+              git \
+              unzip
+      - run:
+          name: Install opencensus extension
+          command: |
+            cd ext
+            phpize
+            ./configure --enable-opencensus
+            sudo make install
+            sudo docker-php-ext-enable opencensus
+      - run:
+          name: Install memcached extension
+          command: |
+            sudo apt-get install -y -q --no-install-recommends \
+              libmemcached11 libmemcached-dev zlib1g-dev zlib1g
+            sudo pecl install memcached <<<''
+            sudo docker-php-ext-enable memcached
+      - run:
+          name: Install pdo_mysql extension
+          command: sudo docker-php-ext-install pdo_mysql
+      - run:
+          name: Install mysqli extension
+          command: sudo docker-php-ext-install mysqli
+      - run:
+          name: Curl test
+          command: tests/integration/curl/test.sh
+      - run:
+          name: Guzzle 5 test
+          command: tests/integration/guzzle5/test.sh
+      - run:
+          name: Guzzle 6 test
+          command: tests/integration/guzzle6/test.sh
+      - run:
+          name: Laravel test
+          command: tests/integration/laravel/test.sh
+      - run:
+          name: Memcached test
+          command: tests/integration/memcached/test.sh
+      - run:
+          name: Wordpress test
+          command: tests/integration/wordpress/test.sh
+    environment:
+      DB_HOST: 127.0.0.1
+      DB_USERNAME: mysql
+      DB_PASSWORD: mysql
+      DB_DATABASE: mysqldb
+
 workflows:
   version: 2
   units:
@@ -168,3 +238,4 @@ workflows:
       - php70-32bit
       - php71-32bit
       - php71-debug
+      - integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,9 @@ jobs:
           name: Memcached test
           command: tests/integration/memcached/test.sh
       - run:
+          name: Symfony 4 test
+          command: tests/integration/symfony4/test.sh
+      - run:
           name: Wordpress test
           command: tests/integration/wordpress/test.sh
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,8 @@ jobs:
       - run:
           name: Symfony 4 test
           command: tests/integration/symfony4/test.sh
+          environment:
+            DATABASE_URL: mysql://mysql:mysql@127.0.0.1:3306/mysqldb
       - run:
           name: Wordpress test
           command: tests/integration/wordpress/test.sh

--- a/src/Trace/Integrations/Eloquent.php
+++ b/src/Trace/Integrations/Eloquent.php
@@ -77,12 +77,9 @@ class Eloquent implements IntegrationInterface
         });
 
         // public function delete()
-        opencensus_trace_method(Model::class, 'delete', function ($model, $query) {
+        opencensus_trace_method(Model::class, 'delete', function ($model) {
             return [
                 'name' => 'eloquent/delete',
-                'attributes' => [
-                    'query' => $query->toBase()->toSql()
-                ],
                 'kind' => Span::KIND_CLIENT
             ];
         });

--- a/src/Trace/Integrations/Memcached.php
+++ b/src/Trace/Integrations/Memcached.php
@@ -45,7 +45,7 @@ class Memcached implements IntegrationInterface
         opencensus_trace_method('Memcached', 'add', [self::class, 'handleAttributes']);
 
         // bool Memcached::addByKey ( string $server_key , string $key , mixed $value [, int $expiration ] )
-        opencensus_trace_method('Memcached', 'add', [self::class, 'handleAttributesByKey']);
+        opencensus_trace_method('Memcached', 'addByKey', [self::class, 'handleAttributesByKey']);
 
         // bool Memcached::append ( string $key , string $value )
         opencensus_trace_method('Memcached', 'append', [self::class, 'handleAttributes']);

--- a/tests/integration/curl/composer.json
+++ b/tests/integration/curl/composer.json
@@ -1,0 +1,16 @@
+{
+    "require": {
+        "php": "^7.2",
+        "opencensus/opencensus": "dev-master",
+        "ext-opencensus": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.0"
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/census-instrumentation/opencensus-php"
+        }
+    ]
+}

--- a/tests/integration/curl/phpunit.xml.dist
+++ b/tests/integration/curl/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite>
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/tests/integration/curl/phpunit.xml.dist
+++ b/tests/integration/curl/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
   <testsuites>
     <testsuite>
       <directory>tests</directory>

--- a/tests/integration/curl/test.sh
+++ b/tests/integration/curl/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${CIRCLE_PR_NUMBER}" ]; then
+    BRANCH="master"
+    REPO="https://github.com/census-instrumentation/opencensus-php"
+else
+    PR_INFO=$(curl "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}")
+    BRANCH=$(echo $PR_INFO | jq -r .head.ref)
+    REPO=$(echo $PR_INFO | jq -r .head.repo.html_url)
+fi
+
+pushd $(dirname ${BASH_SOURCE[0]})
+
+sed -i "s|dev-master|dev-${BRANCH}|" composer.json
+sed -i "s|https://github.com/census-instrumentation/opencensus-php|${REPO}|" composer.json
+composer install -n --prefer-dist
+
+vendor/bin/phpunit
+
+popd

--- a/tests/integration/curl/tests/CurlTest.php
+++ b/tests/integration/curl/tests/CurlTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Integration\Trace;
+
+use OpenCensus\Trace\Tracer;
+use OpenCensus\Trace\Exporter\ExporterInterface;
+use OpenCensus\Trace\Integrations\Curl;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group trace
+ */
+class CurlTest extends TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Curl::load();
+    }
+
+    public function setUp()
+    {
+        if (!extension_loaded('opencensus')) {
+            $this->markTestSkipped('Please enable the opencensus extension.');
+        }
+        opencensus_trace_clear();
+    }
+
+    public function testCurlExec()
+    {
+        $url = 'https://www.google.com/';
+
+        $exporter = $this->prophesize(ExporterInterface::class);
+        $tracer = Tracer::start($exporter->reveal(), [
+            'skipReporting' => true
+        ]);
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        $output = curl_exec($ch);
+        curl_close($ch);
+        $this->assertNotEmpty($output);
+        $tracer->onExit();
+
+        $spans = $tracer->tracer()->spans();
+        $this->assertCount(2, $spans);
+
+        $curlSpan = $spans[1];
+        $this->assertEquals('curl_exec', $curlSpan->name());
+        $this->assertEquals($url, $curlSpan->attributes()['uri']);
+    }
+}

--- a/tests/integration/curl/tests/bootstrap.php
+++ b/tests/integration/curl/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';

--- a/tests/integration/curl/tests/bootstrap.php
+++ b/tests/integration/curl/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';

--- a/tests/integration/guzzle5/composer.json
+++ b/tests/integration/guzzle5/composer.json
@@ -1,0 +1,17 @@
+{
+    "require": {
+        "php": "^7.2",
+        "opencensus/opencensus": "dev-master",
+        "guzzlehttp/guzzle": "^5.0",
+        "ext-opencensus": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.0"
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/census-instrumentation/opencensus-php"
+        }
+    ]
+}

--- a/tests/integration/guzzle5/phpunit.xml.dist
+++ b/tests/integration/guzzle5/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite>
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/tests/integration/guzzle5/phpunit.xml.dist
+++ b/tests/integration/guzzle5/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
   <testsuites>
     <testsuite>
       <directory>tests</directory>

--- a/tests/integration/guzzle5/test.sh
+++ b/tests/integration/guzzle5/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${CIRCLE_PR_NUMBER}" ]; then
+    BRANCH="master"
+    REPO="https://github.com/census-instrumentation/opencensus-php"
+else
+    PR_INFO=$(curl "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}")
+    BRANCH=$(echo $PR_INFO | jq -r .head.ref)
+    REPO=$(echo $PR_INFO | jq -r .head.repo.html_url)
+fi
+
+pushd $(dirname ${BASH_SOURCE[0]})
+
+sed -i "s|dev-master|dev-${BRANCH}|" composer.json
+sed -i "s|https://github.com/census-instrumentation/opencensus-php|${REPO}|" composer.json
+composer install -n --prefer-dist
+
+vendor/bin/phpunit
+
+popd

--- a/tests/integration/guzzle5/tests/Guzzle5Test.php
+++ b/tests/integration/guzzle5/tests/Guzzle5Test.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Integration\Trace;
+
+use GuzzleHttp\Client;
+use OpenCensus\Trace\Tracer;
+use OpenCensus\Trace\Exporter\ExporterInterface;
+use OpenCensus\Trace\Integrations\Guzzle\EventSubscriber;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group trace
+ */
+class Guzzle5Test extends TestCase
+{
+    public function testGuzzleRequest()
+    {
+        $client = new Client();
+        $subscriber = new EventSubscriber();
+        $client->getEmitter()->attach($subscriber);
+
+        $url = 'http://www.google.com/';
+        $exporter = $this->prophesize(ExporterInterface::class);
+        $tracer = Tracer::start($exporter->reveal(), [
+            'skipReporting' => true
+        ]);
+        $response = $client->get($url);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $tracer->onExit();
+
+        $spans = $tracer->tracer()->spans();
+        $this->assertCount(2, $spans);
+
+        $curlSpan = $spans[1];
+        $this->assertEquals('GuzzleHttp::request', $curlSpan->name());
+        $this->assertEquals('GET', $curlSpan->attributes()['method']);
+        $this->assertEquals($url, $curlSpan->attributes()['uri']);
+    }
+}

--- a/tests/integration/guzzle5/tests/bootstrap.php
+++ b/tests/integration/guzzle5/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';

--- a/tests/integration/guzzle5/tests/bootstrap.php
+++ b/tests/integration/guzzle5/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';

--- a/tests/integration/guzzle6/composer.json
+++ b/tests/integration/guzzle6/composer.json
@@ -1,0 +1,17 @@
+{
+    "require": {
+        "php": "^7.2",
+        "opencensus/opencensus": "dev-master",
+        "guzzlehttp/guzzle": "^6.0",
+        "ext-opencensus": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.0"
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/census-instrumentation/opencensus-php"
+        }
+    ]
+}

--- a/tests/integration/guzzle6/phpunit.xml.dist
+++ b/tests/integration/guzzle6/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite>
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/tests/integration/guzzle6/phpunit.xml.dist
+++ b/tests/integration/guzzle6/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
   <testsuites>
     <testsuite>
       <directory>tests</directory>

--- a/tests/integration/guzzle6/test.sh
+++ b/tests/integration/guzzle6/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${CIRCLE_PR_NUMBER}" ]; then
+    BRANCH="master"
+    REPO="https://github.com/census-instrumentation/opencensus-php"
+else
+    PR_INFO=$(curl "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}")
+    BRANCH=$(echo $PR_INFO | jq -r .head.ref)
+    REPO=$(echo $PR_INFO | jq -r .head.repo.html_url)
+fi
+
+pushd $(dirname ${BASH_SOURCE[0]})
+
+sed -i "s|dev-master|dev-${BRANCH}|" composer.json
+sed -i "s|https://github.com/census-instrumentation/opencensus-php|${REPO}|" composer.json
+composer install -n --prefer-dist
+
+vendor/bin/phpunit
+
+popd

--- a/tests/integration/guzzle6/tests/Guzzle6Test.php
+++ b/tests/integration/guzzle6/tests/Guzzle6Test.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Integration\Trace;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use OpenCensus\Trace\Tracer;
+use OpenCensus\Trace\Exporter\ExporterInterface;
+use OpenCensus\Trace\Integrations\Guzzle\Middleware;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group trace
+ */
+class Guzzle5Test extends TestCase
+{
+    public function testGuzzleRequest()
+    {
+        $stack = new HandlerStack();
+        $stack->setHandler(\GuzzleHttp\choose_handler());
+        $stack->push(new Middleware());
+        $client = new Client(['handler' => $stack]);
+
+        $url = 'http://www.google.com/';
+        $exporter = $this->prophesize(ExporterInterface::class);
+        $tracer = Tracer::start($exporter->reveal(), [
+            'skipReporting' => true
+        ]);
+        $response = $client->get($url);
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $tracer->onExit();
+
+        $spans = $tracer->tracer()->spans();
+        $this->assertCount(2, $spans);
+
+        $curlSpan = $spans[1];
+        $this->assertEquals('GuzzleHttp::request', $curlSpan->name());
+        $this->assertEquals('GET', $curlSpan->attributes()['method']);
+        $this->assertEquals($url, $curlSpan->attributes()['uri']);
+    }
+}

--- a/tests/integration/guzzle6/tests/bootstrap.php
+++ b/tests/integration/guzzle6/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__ . '/../vendor/autoload.php';

--- a/tests/integration/guzzle6/tests/bootstrap.php
+++ b/tests/integration/guzzle6/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';

--- a/tests/integration/laravel/app/Http/Controllers/UsersController.php
+++ b/tests/integration/laravel/app/Http/Controllers/UsersController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+
+class UsersController extends Controller
+{
+    public function index()
+    {
+        $users = User::latest()->get();
+        return response()->json($users);
+    }
+
+    public function show(User $user)
+    {
+        return response()->json($user);
+    }
+
+    public function store()
+    {
+        $this->validate(request(), [
+            'name' => 'required',
+            'email' => 'required',
+            'password' => 'required'
+        ]);
+
+        $user = User::create([
+            'name' => request('name'),
+            'email' => request('email'),
+            'password' => request('password')
+        ]);
+
+        return response()->json($user);
+    }
+
+    public function update(User $user)
+    {
+        $user->name = 'New Name';
+        $user->save();
+
+        return response()->json($user);
+    }
+
+    public function delete(User $user)
+    {
+        $user->delete();
+
+        return response()->json(null);
+    }
+}

--- a/tests/integration/laravel/app/Http/Controllers/UsersController.php
+++ b/tests/integration/laravel/app/Http/Controllers/UsersController.php
@@ -1,4 +1,19 @@
 <?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace App\Http\Controllers;
 

--- a/tests/integration/laravel/app/Providers/OpenCensusProvider.php
+++ b/tests/integration/laravel/app/Providers/OpenCensusProvider.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright 2017 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use OpenCensus\Trace\Exporter\FileExporter;
+use OpenCensus\Trace\Tracer;
+use OpenCensus\Trace\Integrations\Laravel;
+use OpenCensus\Trace\Integrations\Mysql;
+use OpenCensus\Trace\Integrations\PDO;
+
+class OpenCensusProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        if (php_sapi_name() == 'cli') {
+            return;
+        }
+
+        // Enable OpenCensus extension integrations
+        Laravel::load();
+        Mysql::load();
+        PDO::load();
+
+        // Start the request tracing for this request
+        $file = sys_get_temp_dir() . '/spans.json';
+        Tracer::start(new FileExporter($file));
+
+        // Create a span that starts from when Laravel first boots (public/index.php)
+        Tracer::inSpan(['name' => 'bootstrap', 'startTime' => LARAVEL_START], function () {});
+    }
+}

--- a/tests/integration/laravel/app/Providers/OpenCensusProvider.php
+++ b/tests/integration/laravel/app/Providers/OpenCensusProvider.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2017 OpenCensus Authors
+ * Copyright 2018 OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/integration/laravel/config/app.php
+++ b/tests/integration/laravel/config/app.php
@@ -1,0 +1,232 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Name
+    |--------------------------------------------------------------------------
+    |
+    | This value is the name of your application. This value is used when the
+    | framework needs to place the application's name in a notification or
+    | any other location as required by the application or its packages.
+    |
+    */
+
+    'name' => env('APP_NAME', 'Laravel'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Environment
+    |--------------------------------------------------------------------------
+    |
+    | This value determines the "environment" your application is currently
+    | running in. This may determine how you prefer to configure various
+    | services your application utilizes. Set this in your ".env" file.
+    |
+    */
+
+    'env' => env('APP_ENV', 'production'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Debug Mode
+    |--------------------------------------------------------------------------
+    |
+    | When your application is in debug mode, detailed error messages with
+    | stack traces will be shown on every error that occurs within your
+    | application. If disabled, a simple generic error page is shown.
+    |
+    */
+
+    'debug' => env('APP_DEBUG', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application URL
+    |--------------------------------------------------------------------------
+    |
+    | This URL is used by the console to properly generate URLs when using
+    | the Artisan command line tool. You should set this to the root of
+    | your application so that it is used when running Artisan tasks.
+    |
+    */
+
+    'url' => env('APP_URL', 'http://localhost'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Timezone
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the default timezone for your application, which
+    | will be used by the PHP date and date-time functions. We have gone
+    | ahead and set this to a sensible default for you out of the box.
+    |
+    */
+
+    'timezone' => 'UTC',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Locale Configuration
+    |--------------------------------------------------------------------------
+    |
+    | The application locale determines the default locale that will be used
+    | by the translation service provider. You are free to set this value
+    | to any of the locales which will be supported by the application.
+    |
+    */
+
+    'locale' => 'en',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Application Fallback Locale
+    |--------------------------------------------------------------------------
+    |
+    | The fallback locale determines the locale to use when the current one
+    | is not available. You may change the value to correspond to any of
+    | the language folders that are provided through your application.
+    |
+    */
+
+    'fallback_locale' => 'en',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Encryption Key
+    |--------------------------------------------------------------------------
+    |
+    | This key is used by the Illuminate encrypter service and should be set
+    | to a random, 32 character string, otherwise these encrypted strings
+    | will not be safe. Please do this before deploying an application!
+    |
+    */
+
+    'key' => env('APP_KEY'),
+
+    'cipher' => 'AES-256-CBC',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Logging Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the log settings for your application. Out of
+    | the box, Laravel uses the Monolog PHP logging library. This gives
+    | you a variety of powerful log handlers / formatters to utilize.
+    |
+    | Available Settings: "single", "daily", "syslog", "errorlog"
+    |
+    */
+
+    'log' => env('APP_LOG', 'single'),
+
+    'log_level' => env('APP_LOG_LEVEL', 'debug'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Autoloaded Service Providers
+    |--------------------------------------------------------------------------
+    |
+    | The service providers listed here will be automatically loaded on the
+    | request to your application. Feel free to add your own services to
+    | this array to grant expanded functionality to your applications.
+    |
+    */
+
+    'providers' => [
+
+        /*
+         * Laravel Framework Service Providers...
+         */
+        Illuminate\Auth\AuthServiceProvider::class,
+        Illuminate\Broadcasting\BroadcastServiceProvider::class,
+        Illuminate\Bus\BusServiceProvider::class,
+        Illuminate\Cache\CacheServiceProvider::class,
+        Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
+        Illuminate\Cookie\CookieServiceProvider::class,
+        Illuminate\Database\DatabaseServiceProvider::class,
+        Illuminate\Encryption\EncryptionServiceProvider::class,
+        Illuminate\Filesystem\FilesystemServiceProvider::class,
+        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
+        Illuminate\Hashing\HashServiceProvider::class,
+        Illuminate\Mail\MailServiceProvider::class,
+        Illuminate\Notifications\NotificationServiceProvider::class,
+        Illuminate\Pagination\PaginationServiceProvider::class,
+        Illuminate\Pipeline\PipelineServiceProvider::class,
+        Illuminate\Queue\QueueServiceProvider::class,
+        Illuminate\Redis\RedisServiceProvider::class,
+        Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
+        Illuminate\Session\SessionServiceProvider::class,
+        Illuminate\Translation\TranslationServiceProvider::class,
+        Illuminate\Validation\ValidationServiceProvider::class,
+        Illuminate\View\ViewServiceProvider::class,
+
+        /*
+         * Package Service Providers...
+         */
+
+        /*
+         * Application Service Providers...
+         */
+        App\Providers\AppServiceProvider::class,
+        App\Providers\AuthServiceProvider::class,
+        // App\Providers\BroadcastServiceProvider::class,
+        App\Providers\EventServiceProvider::class,
+        App\Providers\RouteServiceProvider::class,
+        App\Providers\OpenCensusProvider::class,
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Class Aliases
+    |--------------------------------------------------------------------------
+    |
+    | This array of class aliases will be registered when this application
+    | is started. However, feel free to register as many as you wish as
+    | the aliases are "lazy" loaded so they don't hinder performance.
+    |
+    */
+
+    'aliases' => [
+
+        'App' => Illuminate\Support\Facades\App::class,
+        'Artisan' => Illuminate\Support\Facades\Artisan::class,
+        'Auth' => Illuminate\Support\Facades\Auth::class,
+        'Blade' => Illuminate\Support\Facades\Blade::class,
+        'Broadcast' => Illuminate\Support\Facades\Broadcast::class,
+        'Bus' => Illuminate\Support\Facades\Bus::class,
+        'Cache' => Illuminate\Support\Facades\Cache::class,
+        'Config' => Illuminate\Support\Facades\Config::class,
+        'Cookie' => Illuminate\Support\Facades\Cookie::class,
+        'Crypt' => Illuminate\Support\Facades\Crypt::class,
+        'DB' => Illuminate\Support\Facades\DB::class,
+        'Eloquent' => Illuminate\Database\Eloquent\Model::class,
+        'Event' => Illuminate\Support\Facades\Event::class,
+        'File' => Illuminate\Support\Facades\File::class,
+        'Gate' => Illuminate\Support\Facades\Gate::class,
+        'Hash' => Illuminate\Support\Facades\Hash::class,
+        'Lang' => Illuminate\Support\Facades\Lang::class,
+        'Log' => Illuminate\Support\Facades\Log::class,
+        'Mail' => Illuminate\Support\Facades\Mail::class,
+        'Notification' => Illuminate\Support\Facades\Notification::class,
+        'Password' => Illuminate\Support\Facades\Password::class,
+        'Queue' => Illuminate\Support\Facades\Queue::class,
+        'Redirect' => Illuminate\Support\Facades\Redirect::class,
+        'Redis' => Illuminate\Support\Facades\Redis::class,
+        'Request' => Illuminate\Support\Facades\Request::class,
+        'Response' => Illuminate\Support\Facades\Response::class,
+        'Route' => Illuminate\Support\Facades\Route::class,
+        'Schema' => Illuminate\Support\Facades\Schema::class,
+        'Session' => Illuminate\Support\Facades\Session::class,
+        'Storage' => Illuminate\Support\Facades\Storage::class,
+        'URL' => Illuminate\Support\Facades\URL::class,
+        'Validator' => Illuminate\Support\Facades\Validator::class,
+        'View' => Illuminate\Support\Facades\View::class,
+
+    ],
+
+];

--- a/tests/integration/laravel/phpunit.xml.dist
+++ b/tests/integration/laravel/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/integration/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite>
+      <directory>tests/integration</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/tests/integration/laravel/routes/web.php
+++ b/tests/integration/laravel/routes/web.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register web routes for your application. These
+| routes are loaded by the RouteServiceProvider within a group which
+| contains the "web" middleware group. Now create something great!
+|
+*/
+
+Route::get('/', function () {
+    return view('welcome');
+});
+
+Route::get('/users', 'UsersController@index')->name('index');
+Route::get('/users/store', 'UsersController@store');
+Route::get('/users/{user}/update', 'UsersController@update');
+Route::get('/users/{user}/delete', 'UsersController@delete');
+Route::get('/users/{user}', 'UsersController@show');

--- a/tests/integration/laravel/test.sh
+++ b/tests/integration/laravel/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${CIRCLE_PR_NUMBER}" ]; then
+    BRANCH="master"
+    REPO="https://github.com/census-instrumentation/opencensus-php"
+else
+    PR_INFO=$(curl "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}")
+    BRANCH=$(echo $PR_INFO | jq -r .head.ref)
+    REPO=$(echo $PR_INFO | jq -r .head.repo.html_url)
+fi
+
+pushd $(dirname ${BASH_SOURCE[0]})
+
+composer create-project --prefer-dist laravel/laravel laravel
+cp -R . laravel || true
+
+pushd laravel
+
+composer config repositories.opencensus git ${REPO}
+composer require opencensus/opencensus:dev-${BRANCH}
+composer require --dev phpunit/phpunit:^7.0 guzzlehttp/guzzle:~6.0
+
+php artisan migrate
+vendor/bin/phpunit --config=phpunit.xml.dist
+
+popd
+popd

--- a/tests/integration/laravel/tests/integration/LaravelTest.php
+++ b/tests/integration/laravel/tests/integration/LaravelTest.php
@@ -20,7 +20,7 @@ namespace OpenCensus\Tests\Integration\Trace\Exporter;
 use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
 
-class SilexTest extends TestCase
+class LaravelTest extends TestCase
 {
     private static $outputFile;
     private static $client;

--- a/tests/integration/laravel/tests/integration/LaravelTest.php
+++ b/tests/integration/laravel/tests/integration/LaravelTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Integration\Trace\Exporter;
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class SilexTest extends TestCase
+{
+    private static $outputFile;
+    private static $client;
+
+    public static function setUpBeforeClass()
+    {
+        self::$outputFile = sys_get_temp_dir() . '/spans.json';
+        self::$client = new Client([
+            'base_uri' => getenv('TESTURL') ?: 'http://localhost:9000'
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->clearSpans();
+    }
+
+    public function testReportsTraceToFile()
+    {
+        $rand = mt_rand();
+        $response = self::$client->request('GET', '/', [
+            'query' => [
+                'rand' => $rand
+            ]
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertContains('Laravel', $response->getBody()->getContents());
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+
+        $this->assertEquals('/?rand=' . $rand, $spans[0]['name']);
+        $this->assertNotEmpty($spansByName['bootstrap']);
+        $this->assertNotEmpty($spansByName['laravel/view']);
+    }
+
+    public function testEloquent()
+    {
+        // create a user
+        $email = uniqid() . '@user.com';
+        $response = self::$client->request('GET', '/users/store', [
+            'query' => [
+                'name' => 'Test User',
+                'email' => $email,
+                'password' => 'password'
+            ]
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+        $userData = json_decode($response->getBody()->getContents(), true);
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+        $this->assertNotEmpty($spansByName['bootstrap']);
+        $this->assertNotEmpty($spansByName['eloquent/insert']);
+        $this->assertNotEmpty($spansByName['PDO::__construct']);
+        $this->assertNotEmpty($spansByName['PDO::exec']);
+        $this->assertNotEmpty($spansByName['PDOStatement::execute']);
+
+        $this->clearSpans();
+
+        // find a user
+        $response = self::$client->request('GET', '/users/' . $userData['id']);
+        $this->assertEquals(200, $response->getStatusCode());
+        $userData = json_decode($response->getBody()->getContents(), true);
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+        $this->assertNotEmpty($spansByName['bootstrap']);
+        $this->assertNotEmpty($spansByName['eloquent/get']);
+        $this->assertNotEmpty($spansByName['PDO::__construct']);
+        $this->assertNotEmpty($spansByName['PDO::exec']);
+        $this->assertNotEmpty($spansByName['PDOStatement::execute']);
+
+        $this->clearSpans();
+
+        // list users
+        $response = self::$client->request('GET', '/users');
+        $this->assertEquals(200, $response->getStatusCode());
+        $usersData = json_decode($response->getBody()->getContents(), true);
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+        $this->assertNotEmpty($spansByName['bootstrap']);
+        $this->assertNotEmpty($spansByName['eloquent/get']);
+        $this->assertNotEmpty($spansByName['PDO::__construct']);
+        $this->assertNotEmpty($spansByName['PDO::exec']);
+        $this->assertNotEmpty($spansByName['PDOStatement::execute']);
+
+        $this->clearSpans();
+
+        // update user
+        $response = self::$client->request('GET', '/users/' . $userData['id'] . '/update');
+        $this->assertEquals(200, $response->getStatusCode());
+        $userData = json_decode($response->getBody()->getContents(), true);
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+        $this->assertNotEmpty($spansByName['bootstrap']);
+        $this->assertNotEmpty($spansByName['eloquent/update']);
+        $this->assertNotEmpty($spansByName['PDO::__construct']);
+        $this->assertNotEmpty($spansByName['PDO::exec']);
+        $this->assertNotEmpty($spansByName['PDOStatement::execute']);
+
+        $this->clearSpans();
+
+        // delete user
+        $response = self::$client->request('GET', '/users/' . $userData['id'] . '/delete');
+        $this->assertEquals(200, $response->getStatusCode());
+        $userData = json_decode($response->getBody()->getContents(), true);
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+        $this->assertNotEmpty($spansByName['bootstrap']);
+        $this->assertNotEmpty($spansByName['eloquent/delete']);
+        $this->assertNotEmpty($spansByName['PDO::__construct']);
+        $this->assertNotEmpty($spansByName['PDO::exec']);
+        $this->assertNotEmpty($spansByName['PDOStatement::execute']);
+    }
+
+    private function groupSpansByName($spans)
+    {
+        $spansByName = [];
+        foreach ($spans as $span) {
+            if (!array_key_exists($span['name'], $spansByName)) {
+                $spansByName[$span['name']] = [];
+            }
+            $spansByName[$span['name']][] = $span;
+        }
+        return $spansByName;
+    }
+
+    private function clearSpans()
+    {
+        if (file_exists(self::$outputFile)) {
+            $fp = fopen(self::$outputFile, 'r+');
+            ftruncate($fp, 0);
+            fclose($fp);
+        }
+    }
+}

--- a/tests/integration/laravel/tests/integration/bootstrap.php
+++ b/tests/integration/laravel/tests/integration/bootstrap.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright 2018 OpenCensusAuthors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This PHPUnit bootstrap file starts a local web server using the built-in
+ * PHP web server. The PHPUnit tests that run then hit this running server.
+ * We also register a shutdown function to stop this server after tests have
+ * run.
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$host = getenv('TESTHOST') ?: 'localhost';
+$port = (int)(getenv('TESTPORT') ?: 9000);
+putenv(
+    sprintf(
+        'TESTURL=http://%s:%d',
+        $host,
+        $port
+    )
+);
+
+$command = sprintf(
+    'php artisan serve --host=%s --port=%d >/dev/null 2>&1 & echo $!',
+    $host,
+    $port
+);
+
+$output = [];
+printf('Starting web server with command: %s' . PHP_EOL, $command);
+exec($command, $output);
+$pid = (int) $output[0];
+
+printf(
+    '%s - Web server started on %s:%d with PID %d',
+    date('r'),
+    $host,
+    $port,
+    $pid
+);
+
+// Give the server time to boot.
+sleep(1);
+
+// Kill the web server when the process ends
+register_shutdown_function(function () use ($pid) {
+    echo sprintf('%s - Killing process with ID %d', date('r'), $pid) . PHP_EOL;
+    exec('kill ' . $pid);
+});

--- a/tests/integration/memcached/composer.json
+++ b/tests/integration/memcached/composer.json
@@ -1,0 +1,17 @@
+{
+    "require": {
+        "php": "^7.2",
+        "opencensus/opencensus": "dev-master",
+        "ext-opencensus": "*",
+        "ext-memcached": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.0"
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/census-instrumentation/opencensus-php"
+        }
+    ]
+}

--- a/tests/integration/memcached/phpunit.xml.dist
+++ b/tests/integration/memcached/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
   <testsuites>
     <testsuite>
       <directory>tests</directory>

--- a/tests/integration/memcached/phpunit.xml.dist
+++ b/tests/integration/memcached/phpunit.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite>
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+      <exclude>
+        <directory suffix=".php">src/*/V[!a-zA-Z]*</directory>
+        <directory suffix=".php">src/*/*/V[!a-zA-Z]*</directory>
+        <directory suffix=".php">src/*/*/*/V[!a-zA-Z]*</directory>
+      </exclude>
+    </whitelist>
+  </filter>
+  <logging>
+    <log type="coverage-clover" target="build/clover.xml"/>
+  </logging>
+</phpunit>

--- a/tests/integration/memcached/test.sh
+++ b/tests/integration/memcached/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${CIRCLE_PR_NUMBER}" ]; then
+    BRANCH="master"
+    REPO="https://github.com/census-instrumentation/opencensus-php"
+else
+    PR_INFO=$(curl "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}")
+    BRANCH=$(echo $PR_INFO | jq -r .head.ref)
+    REPO=$(echo $PR_INFO | jq -r .head.repo.html_url)
+fi
+
+pushd $(dirname ${BASH_SOURCE[0]})
+
+sed -i "s|dev-master|dev-${BRANCH}|" composer.json
+sed -i "s|https://github.com/census-instrumentation/opencensus-php|${REPO}|" composer.json
+composer install -n --prefer-dist
+
+vendor/bin/phpunit
+
+popd

--- a/tests/integration/memcached/tests/MemcachedTest.php
+++ b/tests/integration/memcached/tests/MemcachedTest.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Integration\Trace\Exporter;
+
+use OpenCensus\Trace\Tracer;
+use OpenCensus\Trace\Exporter\ExporterInterface;
+use OpenCensus\Trace\Integrations\Memcached as MemcachedIntegration;
+use PHPUnit\Framework\TestCase;
+use Memcached;
+
+class MemcachedTest extends TestCase
+{
+    private $tracer;
+    private static $memcachedHost;
+    private static $memcachedPort;
+
+    public static function setUpBeforeClass()
+    {
+        MemcachedIntegration::load();
+        self::$memcachedHost = getenv('MEMCACHED_HOST') ?: '127.0.0.1';
+        self::$memcachedPort = (int) (getenv('MEMCACHED_PORT') ?: 11211);
+    }
+
+    public function setUp()
+    {
+        if (!extension_loaded('opencensus')) {
+            $this->markTestSkipped('Please enable the opencensus extension.');
+        }
+        opencensus_trace_clear();
+        $exporter = $this->prophesize(ExporterInterface::class);
+        $this->tracer = Tracer::start($exporter->reveal(), [
+            'skipReporting' => true
+        ]);
+    }
+
+    public function testAddGetReplaceDelete()
+    {
+        $m = new Memcached();
+        $m->addServer(self::$memcachedHost, self::$memcachedPort);
+        $m->add('key1', 'bar');
+        $this->assertEquals('bar', $m->get('key1'));
+        $m->replace('key1', 'foo');
+        $this->assertEquals('foo', $m->get('key1'));
+        $m->delete('key1');
+        $this->assertEquals(null, $m->get('key1'));
+
+        $spans = $this->getSpans();
+
+        $this->assertCount(7, $spans);
+        $addSpan = $spans[1];
+        $this->assertEquals('Memcached::add', $addSpan->name());
+        $this->assertEquals('key1', $addSpan->attributes()['key']);
+        $getSpan = $spans[2];
+        $this->assertEquals('Memcached::get', $getSpan->name());
+        $this->assertEquals('key1', $getSpan->attributes()['key']);
+        $replaceSpan = $spans[3];
+        $this->assertEquals('Memcached::replace', $replaceSpan->name());
+        $this->assertEquals('key1', $replaceSpan->attributes()['key']);
+        $deleteSpan = $spans[5];
+        $this->assertEquals('Memcached::delete', $deleteSpan->name());
+        $this->assertEquals('key1', $deleteSpan->attributes()['key']);
+    }
+
+    public function testAddGetDeleteByServerKey()
+    {
+        $serverKey = 'testkey';
+        $m = new Memcached();
+        $m->addServer(self::$memcachedHost, self::$memcachedPort);
+        $m->addByKey($serverKey, 'key2', 'bar');
+        $this->assertEquals('bar', $m->getByKey($serverKey, 'key2'));
+        $m->replaceByKey($serverKey, 'key2', 'foo');
+        $this->assertEquals('foo', $m->getByKey($serverKey, 'key2'));
+        $m->deleteByKey($serverKey, 'key2');
+        $this->assertEquals(null, $m->getByKey($serverKey, 'key2'));
+
+        $spans = $this->getSpans();
+
+        $this->assertCount(7, $spans);
+        $addSpan = $spans[1];
+        $this->assertEquals('Memcached::addByKey', $addSpan->name());
+        $this->assertEquals('key2', $addSpan->attributes()['key']);
+        $this->assertEquals('testkey', $addSpan->attributes()['serverKey']);
+        $getSpan = $spans[2];
+        $this->assertEquals('Memcached::getByKey', $getSpan->name());
+        $this->assertEquals('key2', $getSpan->attributes()['key']);
+        $this->assertEquals('testkey', $getSpan->attributes()['serverKey']);
+        $replaceSpan = $spans[3];
+        $this->assertEquals('Memcached::replaceByKey', $replaceSpan->name());
+        $this->assertEquals('key2', $replaceSpan->attributes()['key']);
+        $this->assertEquals('testkey', $replaceSpan->attributes()['serverKey']);
+        $deleteSpan = $spans[5];
+        $this->assertEquals('Memcached::deleteByKey', $deleteSpan->name());
+        $this->assertEquals('key2', $deleteSpan->attributes()['key']);
+        $this->assertEquals('testkey', $deleteSpan->attributes()['serverKey']);
+    }
+
+    public function testSetAppendPrepend()
+    {
+        $m = new Memcached();
+        $m->addServer(self::$memcachedHost, self::$memcachedPort);
+        $m->setOption(Memcached::OPT_COMPRESSION, false);
+        $m->set('key3', 'abc');
+        $m->append('key3', 'def');
+        $m->prepend('key3', 'xyz');
+        $this->assertEquals('xyzabcdef', $m->get('key3'));
+
+        $spans = $this->getSpans();
+
+        $this->assertCount(5, $spans);
+        $setSpan = $spans[1];
+        $this->assertEquals('Memcached::set', $setSpan->name());
+        $this->assertEquals('key3', $setSpan->attributes()['key']);
+        $appendSpan = $spans[2];
+        $this->assertEquals('Memcached::append', $appendSpan->name());
+        $this->assertEquals('key3', $appendSpan->attributes()['key']);
+        $prependSpan = $spans[3];
+        $this->assertEquals('Memcached::prepend', $prependSpan->name());
+        $this->assertEquals('key3', $prependSpan->attributes()['key']);
+    }
+
+    public function testSetAppendPrependByKey()
+    {
+        $serverKey = 'testkey';
+        $m = new Memcached();
+        $m->addServer(self::$memcachedHost, self::$memcachedPort);
+        $m->setOption(Memcached::OPT_COMPRESSION, false);
+        $m->setByKey($serverKey, 'key4', 'abc');
+        $m->appendByKey($serverKey, 'key4', 'def');
+        $m->prependByKey($serverKey, 'key4', 'xyz');
+        $this->assertEquals('xyzabcdef', $m->get('key4'));
+
+        $spans = $this->getSpans();
+
+        $this->assertCount(5, $spans);
+        $setSpan = $spans[1];
+        $this->assertEquals('Memcached::setByKey', $setSpan->name());
+        $this->assertEquals('key4', $setSpan->attributes()['key']);
+        $this->assertEquals('testkey', $setSpan->attributes()['serverKey']);
+        $appendSpan = $spans[2];
+        $this->assertEquals('Memcached::appendByKey', $appendSpan->name());
+        $this->assertEquals('key4', $appendSpan->attributes()['key']);
+        $this->assertEquals('testkey', $appendSpan->attributes()['serverKey']);
+        $prependSpan = $spans[3];
+        $this->assertEquals('Memcached::prependByKey', $prependSpan->name());
+        $this->assertEquals('key4', $prependSpan->attributes()['key']);
+        $this->assertEquals('testkey', $prependSpan->attributes()['serverKey']);
+    }
+
+    public function testFlushIncrementDecrement()
+    {
+        $m = new Memcached();
+        $m->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
+        $m->addServer(self::$memcachedHost, self::$memcachedPort);
+        $m->flush();
+        $m->increment('key5', 1, 1);
+        $m->increment('key5', 1);
+        $this->assertEquals(2, $m->get('key5'));
+        $m->decrement('key5', 1);
+        $this->assertEquals(1, $m->get('key5'));
+
+        $spans = $this->getSpans();
+        $this->assertCount(7, $spans);
+        $flushSpan = $spans[1];
+        $this->assertEquals('Memcached::flush', $flushSpan->name());
+        $incrementSpan = $spans[2];
+        $this->assertEquals('Memcached::increment', $incrementSpan->name());
+        $this->assertEquals('key5', $incrementSpan->attributes()['key']);
+        $decrementSpan = $spans[5];
+        $this->assertEquals('Memcached::decrement', $decrementSpan->name());
+        $this->assertEquals('key5', $decrementSpan->attributes()['key']);
+    }
+
+    public function testFlushIncrementDecrementByKey()
+    {
+        $serverKey = 'testkey';
+        $m = new Memcached();
+        $m->setOption(Memcached::OPT_BINARY_PROTOCOL, true);
+        $m->addServer(self::$memcachedHost, self::$memcachedPort);
+        $m->flush();
+        $m->incrementByKey($serverKey, 'key5', 1, 1);
+        $m->incrementByKey($serverKey, 'key5', 1);
+        $this->assertEquals(2, $m->getByKey($serverKey, 'key5'));
+        $m->decrementByKey($serverKey, 'key5', 1);
+        $this->assertEquals(1, $m->getByKey($serverKey, 'key5'));
+
+        $spans = $this->getSpans();
+        $this->assertCount(7, $spans);
+        $flushSpan = $spans[1];
+        $this->assertEquals('Memcached::flush', $flushSpan->name());
+        $incrementSpan = $spans[2];
+        $this->assertEquals('Memcached::incrementByKey', $incrementSpan->name());
+        $this->assertEquals('key5', $incrementSpan->attributes()['key']);
+        $this->assertEquals('testkey', $incrementSpan->attributes()['serverKey']);
+        $decrementSpan = $spans[5];
+        $this->assertEquals('Memcached::decrementByKey', $decrementSpan->name());
+        $this->assertEquals('key5', $decrementSpan->attributes()['key']);
+        $this->assertEquals('testkey', $decrementSpan->attributes()['serverKey']);
+    }
+
+    public function testCas()
+    {
+        $cas = null;
+        $m = new Memcached();
+        $m->addServer(self::$memcachedHost, self::$memcachedPort);
+        $ips = $m->get('ip_block', null, $cas);
+        $m->cas($cas, 'ip_block', ['127.0.0.1']);
+
+        $spans = $this->getSpans();
+        $this->assertCount(3, $spans);
+        $casSpan = $spans[2];
+        $this->assertEquals('Memcached::cas', $casSpan->name());
+        $this->assertEquals('ip_block', $casSpan->attributes()['key']);
+    }
+
+    public function testCasByKey()
+    {
+        $serverKey = 'serverkey';
+        $cas = null;
+        $m = new Memcached();
+        $m->addServer(self::$memcachedHost, self::$memcachedPort);
+        $ips = $m->get('ip_block', null, $cas);
+        $m->casByKey($cas, $serverKey, 'ip_block', ['127.0.0.1']);
+
+        $spans = $this->getSpans();
+        $this->assertCount(3, $spans);
+        $casSpan = $spans[2];
+        $this->assertEquals('Memcached::casByKey', $casSpan->name());
+        $this->assertEquals('ip_block', $casSpan->attributes()['key']);
+    }
+
+    public function testSetGetMulti()
+    {
+        $m = new Memcached();
+        $m->addServer(self::$memcachedHost, self::$memcachedPort);
+        $m->setMulti([
+            'foo' => 'bar',
+            'asdf' => 'qwer'
+        ]);
+        $this->assertEquals([
+            'foo' => 'bar',
+            'asdf' => 'qwer'
+        ], $m->getMulti(['foo', 'asdf']));
+
+        $spans = $this->getSpans();
+        $this->assertCount(3, $spans);
+        $setSpan = $spans[1];
+        $this->assertEquals('Memcached::setMulti', $setSpan->name());
+        $this->assertEquals('foo,asdf', $setSpan->attributes()['key']);
+        $getSpan = $spans[2];
+        $this->assertEquals('Memcached::getMulti', $getSpan->name());
+        $this->assertEquals('foo,asdf', $getSpan->attributes()['key']);
+    }
+
+    public function testSetGetMultiByKey()
+    {
+        $serverKey = 'testkey';
+        $m = new Memcached();
+        $m->addServer(self::$memcachedHost, self::$memcachedPort);
+        $m->setMultiByKey($serverKey, [
+            'foo' => 'bar',
+            'asdf' => 'qwer'
+        ]);
+        $this->assertEquals([
+            'foo' => 'bar',
+            'asdf' => 'qwer'
+        ], $m->getMultiByKey($serverKey, ['foo', 'asdf']));
+
+        $spans = $this->getSpans();
+        $this->assertCount(3, $spans);
+        $setSpan = $spans[1];
+        $this->assertEquals('Memcached::setMultiByKey', $setSpan->name());
+        $this->assertEquals('foo,asdf', $setSpan->attributes()['key']);
+        $this->assertEquals('testkey', $setSpan->attributes()['serverKey']);
+        $getSpan = $spans[2];
+        $this->assertEquals('Memcached::getMultiByKey', $getSpan->name());
+        $this->assertEquals('foo,asdf', $getSpan->attributes()['key']);
+        $this->assertEquals('testkey', $getSpan->attributes()['serverKey']);
+    }
+
+    private function getSpans()
+    {
+        $this->tracer->onExit();
+        return $this->tracer->tracer()->spans();
+    }
+}

--- a/tests/integration/memcached/tests/bootstrap.php
+++ b/tests/integration/memcached/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/integration/memcached/tests/bootstrap.php
+++ b/tests/integration/memcached/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../vendor/autoload.php';

--- a/tests/integration/symfony4/phpunit.xml.dist
+++ b/tests/integration/symfony4/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite>
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/tests/integration/symfony4/src/Controller/UserController.php
+++ b/tests/integration/symfony4/src/Controller/UserController.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace App\Controller;
+
+use App\Entity\User;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class UserController extends Controller
+{
+    /**
+     * @Route("/", name="home")
+     */
+    public function homepage()
+    {
+        return new Response('Hello world!');
+    }
+
+    /**
+     * @Route("/user", name="user")
+     */
+    public function index()
+    {
+        $users = $this->getDoctrine()
+            ->getRepository(User::class)
+            ->findAll();
+
+        return $this->json(array_map([$this, 'userToJson'], $users));
+    }
+
+    /**
+     * @Route("/user/create", name="user_create")
+     */
+    public function create()
+    {
+        $entityManager = $this->getDoctrine()->getManager();
+
+        $user = new User();
+        $user->setName('New User');
+        $entityManager->persist($user);
+        $entityManager->flush();
+
+        return $this->json($this->userToJson($user));
+    }
+
+    /**
+     * @Route("/user/{id}", name="user_show")
+     */
+    public function show($id)
+    {
+        $repository = $this->getDoctrine()->getRepository(User::class);
+        $user = $repository->findOneBy(['id' => $id]);
+        return $this->json($this->userToJson($user));
+    }
+
+    /**
+     * @Route("/user/{id}/update")
+     */
+    public function update($id)
+    {
+        $entityManager = $this->getDoctrine()->getManager();
+        $user = $entityManager->getRepository(User::class)->find($id);
+
+        if (!$user) {
+            throw $this->createNotFoundException(
+                'No user found for id '.$id
+            );
+        }
+
+        $user->setName('New Name');
+        $entityManager->flush();
+
+        return $this->json($this->userToJson($user));
+    }
+
+    /**
+     * @Route("/user/{id}/delete")
+     */
+    public function delete($id)
+    {
+        $entityManager = $this->getDoctrine()->getManager();
+        $user = $entityManager->getRepository(User::class)->find($id);
+        $entityManager->remove($user);
+        $entityManager->flush();
+
+        return $this->json([]);
+    }
+
+    private function userToJson($user)
+    {
+        return [
+            'id' => $user->getId(),
+            'name' => $user->getName()
+        ];
+    }
+}

--- a/tests/integration/symfony4/src/Entity/User.php
+++ b/tests/integration/symfony4/src/Entity/User.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="App\Repository\UserRepository")
+ */
+class User
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/tests/integration/symfony4/src/EventSubscriber/OpenCensusSubscriber.php
+++ b/tests/integration/symfony4/src/EventSubscriber/OpenCensusSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use OpenCensus\Trace\Exporter\FileExporter;
+use OpenCensus\Trace\Tracer;
+use OpenCensus\Trace\Integrations\Symfony;
+
+class OpenCensusSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        // return the subscribed events, their methods and priorities
+        return array(
+           KernelEvents::REQUEST => ['startTrace', 10]
+        );
+    }
+
+    public function startTrace(GetResponseEvent $event)
+    {
+        Symfony::load();
+
+        $file = sys_get_temp_dir() . '/spans.json';
+        Tracer::start(new FileExporter($file));
+    }
+}

--- a/tests/integration/symfony4/src/Migrations/Version20180504202739.php
+++ b/tests/integration/symfony4/src/Migrations/Version20180504202739.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180504202739 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE user (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE user');
+    }
+}

--- a/tests/integration/symfony4/src/Repository/UserRepository.php
+++ b/tests/integration/symfony4/src/Repository/UserRepository.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace App\Repository;
+
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+
+/**
+ * @method User|null find($id, $lockMode = null, $lockVersion = null)
+ * @method User|null findOneBy(array $criteria, array $orderBy = null)
+ * @method User[]    findAll()
+ * @method User[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class UserRepository extends ServiceEntityRepository
+{
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+}

--- a/tests/integration/symfony4/test.sh
+++ b/tests/integration/symfony4/test.sh
@@ -22,7 +22,6 @@ composer config repositories.opencensus git ${REPO}
 composer require opencensus/opencensus:dev-${BRANCH} doctrine
 composer require --dev phpunit/phpunit:^7.0 guzzlehttp/guzzle:~6.0
 
-bin/console doctrine:database:create
 bin/console doctrine:migrations:migrate
 vendor/bin/phpunit
 

--- a/tests/integration/symfony4/test.sh
+++ b/tests/integration/symfony4/test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${CIRCLE_PR_NUMBER}" ]; then
+    BRANCH="master"
+    REPO="https://github.com/census-instrumentation/opencensus-php"
+else
+    PR_INFO=$(curl "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}")
+    BRANCH=$(echo $PR_INFO | jq -r .head.ref)
+    REPO=$(echo $PR_INFO | jq -r .head.repo.html_url)
+fi
+
+pushd $(dirname ${BASH_SOURCE[0]})
+
+composer create-project --prefer-dist symfony/skeleton symfony ^4.0
+cp -r src tests phpunit.xml.dist symfony/
+
+pushd symfony
+
+composer config repositories.opencensus git ${REPO}
+composer require opencensus/opencensus:dev-${BRANCH} doctrine
+composer require --dev phpunit/phpunit:^7.0 guzzlehttp/guzzle:~6.0
+
+bin/console doctrine:database:create
+bin/console doctrine:migrations:migrate
+vendor/bin/phpunit
+
+popd
+popd

--- a/tests/integration/symfony4/test.sh
+++ b/tests/integration/symfony4/test.sh
@@ -22,7 +22,7 @@ composer config repositories.opencensus git ${REPO}
 composer require opencensus/opencensus:dev-${BRANCH} doctrine
 composer require --dev phpunit/phpunit:^7.0 guzzlehttp/guzzle:~6.0
 
-bin/console doctrine:migrations:migrate
+bin/console doctrine:migrations:migrate -n
 vendor/bin/phpunit
 
 popd

--- a/tests/integration/symfony4/tests/SymfonyTest.php
+++ b/tests/integration/symfony4/tests/SymfonyTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Integration\Trace\Exporter;
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class SymfonyTest extends TestCase
+{
+    private static $outputFile;
+    private static $client;
+
+    public static function setUpBeforeClass()
+    {
+        self::$outputFile = sys_get_temp_dir() . '/spans.json';
+        self::$client = new Client([
+            'base_uri' => getenv('TESTURL') ?: 'http://localhost:9000'
+        ]);
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->clearSpans();
+    }
+
+    public function testReportsTraceToFile()
+    {
+        $rand = mt_rand();
+        $response = self::$client->request('GET', '/', [
+            'query' => [
+                'rand' => $rand
+            ]
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertContains('Hello world!', $response->getBody()->getContents());
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+
+        $this->assertEquals('/?rand=' . $rand, $spans[0]['name']);
+        $this->assertNotEmpty($spansByName['kernel.controller']);
+        $this->assertNotEmpty($spansByName['kernel.controller_arguments']);
+        $this->assertNotEmpty($spansByName['kernel.response']);
+        $this->assertNotEmpty($spansByName['kernel.finish_request']);
+        $this->assertNotEmpty($spansByName['kernel.terminate']);
+    }
+
+    public function testDoctrine()
+    {
+        // create a user
+        $email = uniqid() . '@user.com';
+        $response = self::$client->request('GET', '/user/create');
+        $this->assertEquals(200, $response->getStatusCode());
+        $userData = json_decode($response->getBody()->getContents(), true);
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+        $this->assertNotEmpty($spansByName['PDO::__construct']);
+        $this->assertNotEmpty($spansByName['PDOStatement::execute']);
+        $this->assertNotEmpty($spansByName['PDO::commit']);
+
+        $this->clearSpans();
+
+        // find a user
+        $response = self::$client->request('GET', '/user/' . $userData['id']);
+        $this->assertEquals(200, $response->getStatusCode());
+        $userData = json_decode($response->getBody()->getContents(), true);
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+        $this->assertNotEmpty($spansByName['doctrine/load']);
+        $this->assertNotEmpty($spansByName['PDO::__construct']);
+        $this->assertNotEmpty($spansByName['PDOStatement::execute']);
+
+        $this->clearSpans();
+
+        // list users
+        $response = self::$client->request('GET', '/user');
+        $this->assertEquals(200, $response->getStatusCode());
+        $usersData = json_decode($response->getBody()->getContents(), true);
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+        $this->assertNotEmpty($spansByName['doctrine/loadAll']);
+        $this->assertNotEmpty($spansByName['PDO::__construct']);
+        $this->assertNotEmpty($spansByName['PDO::query']);
+
+        $this->clearSpans();
+
+        // update user
+        $response = self::$client->request('GET', '/user/' . $userData['id'] . '/update');
+        $this->assertEquals(200, $response->getStatusCode());
+        $userData = json_decode($response->getBody()->getContents(), true);
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+        $this->assertNotEmpty($spansByName['doctrine/load']);
+        $this->assertNotEmpty($spansByName['PDO::__construct']);
+        $this->assertNotEmpty($spansByName['PDOStatement::execute']);
+        $this->assertNotEmpty($spansByName['PDO::commit']);
+
+        $this->clearSpans();
+
+        // delete user
+        $response = self::$client->request('GET', '/user/' . $userData['id'] . '/delete');
+        $this->assertEquals(200, $response->getStatusCode());
+        $userData = json_decode($response->getBody()->getContents(), true);
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = $this->groupSpansByName($spans);
+        $this->assertNotEmpty($spansByName['doctrine/load']);
+        $this->assertNotEmpty($spansByName['PDO::__construct']);
+        $this->assertNotEmpty($spansByName['PDOStatement::execute']);
+        $this->assertNotEmpty($spansByName['PDO::commit']);
+    }
+
+    private function groupSpansByName($spans)
+    {
+        $spansByName = [];
+        foreach ($spans as $span) {
+            if (!array_key_exists($span['name'], $spansByName)) {
+                $spansByName[$span['name']] = [];
+            }
+            $spansByName[$span['name']][] = $span;
+        }
+        return $spansByName;
+    }
+
+    private function clearSpans()
+    {
+        if (file_exists(self::$outputFile)) {
+            $fp = fopen(self::$outputFile, 'r+');
+            ftruncate($fp, 0);
+            fclose($fp);
+        }
+    }
+}

--- a/tests/integration/symfony4/tests/bootstrap.php
+++ b/tests/integration/symfony4/tests/bootstrap.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright 2018 OpenCensusAuthors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This PHPUnit bootstrap file starts a local web server using the built-in
+ * PHP web server. The PHPUnit tests that run then hit this running server.
+ * We also register a shutdown function to stop this server after tests have
+ * run.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$host = getenv('TESTHOST') ?: 'localhost';
+$port = (int)(getenv('TESTPORT') ?: 9000);
+putenv(
+    sprintf(
+        'TESTURL=http://%s:%d',
+        $host,
+        $port
+    )
+);
+
+$command = sprintf(
+    'php -S %s:%d -t %s >/dev/null 2>&1 & echo $!',
+    $host,
+    $port,
+    __DIR__ . '/../public'
+);
+
+$output = [];
+printf('Starting web server with command: %s' . PHP_EOL, $command);
+exec($command, $output);
+$pid = (int) $output[0];
+
+printf(
+    '%s - Web server started on %s:%d with PID %d',
+    date('r'),
+    $host,
+    $port,
+    $pid
+);
+
+// Give the server time to boot.
+sleep(1);
+
+// Kill the web server when the process ends
+register_shutdown_function(function () use ($pid) {
+    echo sprintf('%s - Killing process with ID %d', date('r'), $pid) . PHP_EOL;
+    exec('kill ' . $pid);
+});

--- a/tests/integration/wordpress/composer.json
+++ b/tests/integration/wordpress/composer.json
@@ -1,0 +1,18 @@
+{
+    "require": {
+        "php": "^7.2",
+        "opencensus/opencensus": "dev-master",
+        "ext-opencensus": "*"
+    },
+    "require-dev": {
+        "wp-cli/wp-cli": "~1.1",
+        "phpunit/phpunit": "^7.0",
+        "guzzlehttp/guzzle": "~6.0"
+    },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/census-instrumentation/opencensus-php"
+        }
+    ]
+}

--- a/tests/integration/wordpress/phpunit.xml.dist
+++ b/tests/integration/wordpress/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./tests/integration/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite>
+      <directory>tests/integration</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">src</directory>
+    </whitelist>
+  </filter>
+</phpunit>

--- a/tests/integration/wordpress/test.sh
+++ b/tests/integration/wordpress/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${CIRCLE_PR_NUMBER}" ]; then
+    BRANCH="master"
+    REPO="https://github.com/census-instrumentation/opencensus-php"
+else
+    PR_INFO=$(curl "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER}")
+    BRANCH=$(echo $PR_INFO | jq -r .head.ref)
+    REPO=$(echo $PR_INFO | jq -r .head.repo.html_url)
+fi
+
+pushd $(dirname ${BASH_SOURCE[0]})
+
+curl -L https://wordpress.org/latest.tar.gz | tar zxf -
+sed -i "s|dev-master|dev-${BRANCH}|" composer.json
+sed -i "s|https://github.com/census-instrumentation/opencensus-php|${REPO}|" composer.json
+composer install -n --prefer-dist
+cp wp-config.php wordpress
+vendor/bin/wp core install  --admin_user=admin \
+                            --admin_password=password \
+                            --allow-root \
+                            --path=wordpress/ \
+                            --url=http://wordpress/ \
+                            --admin_email=admin@opencensus.io \
+                            --title="OpenCensus Test"
+
+vendor/bin/phpunit
+
+popd

--- a/tests/integration/wordpress/tests/integration/WordpressTest.php
+++ b/tests/integration/wordpress/tests/integration/WordpressTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Tests\Integration\Trace\Exporter;
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class SilexTest extends TestCase
+{
+    private static $outputFile;
+
+    public static function setUpBeforeClass()
+    {
+        self::$outputFile = sys_get_temp_dir() . '/spans.json';
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+        if (file_exists(self::$outputFile)) {
+            $fp = fopen(self::$outputFile, 'r+');
+            ftruncate($fp, 0);
+            fclose($fp);
+        }
+    }
+
+    public function testReportsTraceToFile()
+    {
+        $rand = mt_rand();
+        $client = new Client(['base_uri' => 'http://localhost:9000']);
+        $response = $client->request('GET', '/', [
+            'query' => [
+                'rand' => $rand
+            ]
+        ]);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertContains('Hello world!', $response->getBody()->getContents());
+
+        $spans = json_decode(file_get_contents(self::$outputFile), true);
+        $this->assertNotEmpty($spans);
+
+        $spansByName = [];
+        foreach ($spans as $span) {
+            if (!array_key_exists($span['name'], $spansByName)) {
+                $spansByName[$span['name']] = [];
+            }
+            $spansByName[$span['name']][] = $span;
+        }
+
+        $this->assertEquals('/?rand=' . $rand, $spans[0]['name']);
+        $this->assertNotEmpty($spansByName['mysqli_query']);
+        $this->assertNotEmpty($spansByName['load_textdomain']);
+        $this->assertNotEmpty($spansByName['get_header']);
+        $this->assertNotEmpty($spansByName['load_template']);
+        $this->assertNotEmpty($spansByName['get_sidebar']);
+        $this->assertNotEmpty($spansByName['get_footer']);
+    }
+}

--- a/tests/integration/wordpress/tests/integration/WordpressTest.php
+++ b/tests/integration/wordpress/tests/integration/WordpressTest.php
@@ -20,7 +20,7 @@ namespace OpenCensus\Tests\Integration\Trace\Exporter;
 use GuzzleHttp\Client;
 use PHPUnit\Framework\TestCase;
 
-class SilexTest extends TestCase
+class WordpressTest extends TestCase
 {
     private static $outputFile;
 

--- a/tests/integration/wordpress/tests/integration/bootstrap.php
+++ b/tests/integration/wordpress/tests/integration/bootstrap.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright 2018 OpenCensusAuthors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This PHPUnit bootstrap file starts a local web server using the built-in
+ * PHP web server. The PHPUnit tests that run then hit this running server.
+ * We also register a shutdown function to stop this server after tests have
+ * run.
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$host = getenv('TESTHOST') ?: 'localhost';
+$port = (int)(getenv('TESTPORT') ?: 9000);
+putenv(
+    sprintf(
+        'TESTURL=http://%s:%d',
+        $host,
+        $port
+    )
+);
+
+$command = sprintf(
+    'php -S %s:%d -t %s >/dev/null 2>&1 & echo $!',
+    $host,
+    $port,
+    __DIR__ . '/../../wordpress'
+);
+
+$output = [];
+printf('Starting web server with command: %s' . PHP_EOL, $command);
+exec($command, $output);
+$pid = (int) $output[0];
+
+printf(
+    '%s - Web server started on %s:%d with PID %d',
+    date('r'),
+    $host,
+    $port,
+    $pid
+);
+
+// Give the server time to boot.
+sleep(1);
+
+// Kill the web server when the process ends
+register_shutdown_function(function () use ($pid) {
+    echo sprintf('%s - Killing process with ID %d', date('r'), $pid) . PHP_EOL;
+    exec('kill ' . $pid);
+});

--- a/tests/integration/wordpress/wp-config.php
+++ b/tests/integration/wordpress/wp-config.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the
+ * installation. You don't have to use the web site, you can
+ * copy this file to "wp-config.php" and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * MySQL settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://codex.wordpress.org/Editing_wp-config.php
+ *
+ * @package WordPress
+ */
+
+require_once(__DIR__ . '/../vendor/autoload.php');
+
+if (php_sapi_name() !== 'cli') {
+    $file = sys_get_temp_dir() . '/spans.json';
+    $exporter = new OpenCensus\Trace\Exporter\FileExporter($file);
+    OpenCensus\Trace\Integrations\Wordpress::load();
+    OpenCensus\Trace\Integrations\Mysql::load();
+
+    OpenCensus\Trace\Tracer::start($exporter);
+}
+
+// Disable pseudo cron behavior
+define('DISABLE_WP_CRON', true);
+
+// Determine HTTP or HTTPS, then set WP_SITEURL and WP_HOME
+if (isset($_SERVER['HTTP_HOST'])) {
+    define('HTTP_HOST', $_SERVER['HTTP_HOST']);
+} else {
+    define('HTTP_HOST', 'localhost');
+}
+// Use https on production.
+define('WP_HOME', 'http://' . HTTP_HOST);
+define('WP_SITEURL', 'http://' . HTTP_HOST);
+
+// Force SSL for admin pages
+define('FORCE_SSL_ADMIN', false);
+
+/** Production environment */
+define('DB_HOST', getenv('DB_HOST') ?: 'localhost');
+/** The name of the database for WordPress */
+define('DB_NAME', getenv('DB_DATABASE') ?: 'wordpress');
+/** MySQL database username */
+define('DB_USER', getenv('DB_USERNAME') ?: 'wordpress');
+/** MySQL database password */
+define('DB_PASSWORD', getenv('DB_PASSWORD') ?: 'wordpress');
+
+/** Database Charset to use in creating database tables. */
+define('DB_CHARSET', 'utf8');
+
+/** The Database Collate type. Don't change this if in doubt. */
+define('DB_COLLATE', '');
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * @since 2.6.0
+ */
+
+define('AUTH_KEY',         'S6sf+AtNsorbl7wECg22BIZWfk/Ye0HZjXNd+/NGGYKIE2CFSzGBRrSNmT+82t0j0YqheMk1atDU9EtN');
+define('SECURE_AUTH_KEY',  'e27t0A3c5+bZMSgc8nK5DXdbPWmpYtrnOjRRaFvgE5dZ/hXkssN+6fxf0fvz/dhofydbPnW8GLzWwV5b');
+define('LOGGED_IN_KEY',    '4qJxVidveTpegoLzWO4Vk6wvWeFomjlvWYFSsFkn6zMhCcrY9TI6VGf7sYLveJph/WS09ZnqVaqiZXDB');
+define('NONCE_KEY',        'q8X6MzapmbBJs1AgYOSbJscmMFI3CjW/MRrRk5buvNyieYEU0Q27fwGw0FpZhftuwdXlobRRk2d5c8s2');
+define('AUTH_SALT',        'x7If3xO6giDWQdzqrPZmz8F9iVeu50eZdiMpvrIjmleleFC7gR7ag06gGt/QlvoYBob/EHk46mC2rgES');
+define('SECURE_AUTH_SALT', 'RfLenlKmT2uSfEQ+v75r87u6lRofKGoOZPlxq8QFiOzYiwy4i70D58Hg500fJ+s4YYXrNw1LPOjk9SKM');
+define('LOGGED_IN_SALT',   'ZCmRKtiu9ExC1YGTQ1txmjGikP+DWB2zrCUWKn4iws88tKe3mtLTDV0wL9Zwl/Hn+W/r5uZ6eh7RCyqP');
+define('NONCE_SALT',       '5FKi89HYMuCCBpLjjqXu9jKQdPq5nk+cCDLtu9HCdNFSL2dPz9V8L4uX/dnaNekj/mNCqEgzXK5LLKCC');
+
+/**#@-*/
+
+/**
+ * WordPress Database Table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix  = 'wp_';
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the Codex.
+ *
+ * @link https://codex.wordpress.org/Debugging_in_WordPress
+ */
+define('WP_DEBUG', false);
+
+/* That's all, stop editing! Happy blogging. */
+
+/** Absolute path to the WordPress directory. */
+if (!defined('ABSPATH')) {
+    define('ABSPATH', dirname(__FILE__) . '/');
+}
+
+/** Sets up WordPress vars and included files. */
+require_once(ABSPATH . 'wp-settings.php');


### PR DESCRIPTION
Adds an integration test to Circle CI

* Runs memcache and mysql servers for tests
* Generates and tests a wordpress instance
* Generates and tests a laravel instance (with Eloquent using mysql)

Note: to test the current branch, we replace the repo/branch in the composer.json before installing dependencies.

See #120