### PR TITLE
Extension: Fix timing memory management for callback arguments

### DIFF
--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -627,6 +627,7 @@ void opencensus_trace_execute_ex (zend_execute_data *execute_data TSRMLS_DC) {
             opencensus_trace_span_apply_span_options(span, &callback_result);
         }
         opencensus_free_args(args, num_args);
+        ZVAL_DESTRUCTOR(&callback_result);
     } else {
         /* Registered handler is span options array */
         opencensus_original_zend_execute_ex(execute_data TSRMLS_CC);
@@ -634,6 +635,7 @@ void opencensus_trace_execute_ex (zend_execute_data *execute_data TSRMLS_DC) {
             opencensus_trace_span_apply_span_options(span, trace_handler);
         }
     }
+    zend_string_release(callback_name);
     opencensus_trace_finish();
 }
 
@@ -692,6 +694,7 @@ void opencensus_trace_execute_internal(INTERNAL_FUNCTION_PARAMETERS)
             opencensus_trace_span_apply_span_options(span, &callback_result);
         }
         opencensus_free_args(args, num_args);
+        ZVAL_DESTRUCTOR(&callback_result);
     } else {
         /* Registered handler is span options array */
         resume_execute_internal(INTERNAL_FUNCTION_PARAM_PASSTHRU);
@@ -699,6 +702,7 @@ void opencensus_trace_execute_internal(INTERNAL_FUNCTION_PARAMETERS)
             opencensus_trace_span_apply_span_options(span, trace_handler);
         }
     }
+    zend_string_release(callback_name);
     opencensus_trace_finish();
 }
 

--- a/ext/opencensus_trace.c
+++ b/ext/opencensus_trace.c
@@ -302,35 +302,43 @@ PHP_FUNCTION(opencensus_trace_add_message_event)
     RETURN_FALSE;
 }
 
+static void opencensus_copy_args(zend_execute_data *execute_data, zval **args, int *ret_num_args)
+{
+    int i, num_args = ZEND_CALL_NUM_ARGS(execute_data), has_scope = 0;
+    zval *arguments = emalloc((num_args + 1) * sizeof(zval));
+    *args = arguments;
+
+    if (getThis() != NULL) {
+        has_scope = 1;
+        // printf("copying this of type: %d\n", Z_TYPE_P(getThis()));
+        ZVAL_COPY(&arguments[0], getThis());
+    }
+
+    for (i = 0; i < num_args; i++) {
+        // printf("copying arg of type: %d\n", Z_TYPE_P(ZEND_CALL_VAR_NUM(execute_data, i)));
+        ZVAL_COPY(&arguments[i + has_scope], ZEND_CALL_VAR_NUM(execute_data, i));
+    }
+    *ret_num_args = num_args + has_scope;
+}
+
+static void opencensus_free_args(zval *args, int num_args)
+{
+    int i;
+    for (i = 0; i < num_args; i++) {
+        ZVAL_DESTRUCTOR(&args[i]);
+    }
+    efree(args);
+}
+
 /**
  * Call the provided callback with the provided parameters to the traced
  * function. The callback must return an array or an E_WARNING is raised.
  */
-static int opencensus_trace_call_user_function_callback(zend_execute_data *execute_data, opencensus_trace_span_t *span, zval *callback, zval *callback_result TSRMLS_DC)
+static int opencensus_trace_call_user_function_callback(zval *args, int num_args, zend_execute_data *execute_data, opencensus_trace_span_t *span, zval *callback, zval *callback_result TSRMLS_DC)
 {
-    int i, num_args = ZEND_CALL_NUM_ARGS(execute_data), has_scope = 0;
-    zval *args = emalloc((num_args + 1) * sizeof(zval));
-
-    if (getThis() != NULL) {
-        has_scope = 1;
-        ZVAL_COPY(&args[0], getThis());
-    }
-
-    for (i = 0; i < num_args; i++) {
-        ZVAL_COPY(&args[i + has_scope], ZEND_CALL_VAR_NUM(execute_data, i));
-    }
-
-    if (call_user_function_ex(EG(function_table), NULL, callback, callback_result, num_args + has_scope, args, 0, NULL) != SUCCESS) {
-        for (i = 0; i < num_args + has_scope; i++) {
-            ZVAL_DESTRUCTOR(&args[i]);
-        }
-        efree(args);
+    if (call_user_function_ex(EG(function_table), NULL, callback, callback_result, num_args, args, 0, NULL) != SUCCESS) {
         return FAILURE;
     }
-    for (i = 0; i < num_args + has_scope; i++) {
-        ZVAL_DESTRUCTOR(&args[i]);
-    }
-    efree(args);
 
     if (EG(exception) != NULL) {
         php_error_docref(NULL, E_WARNING, "Exception in trace callback");
@@ -345,29 +353,6 @@ static int opencensus_trace_call_user_function_callback(zend_execute_data *execu
     }
 
     return SUCCESS;
-}
-
-/**
- * Handle the callback for the traced method depending on the type
- * - if the zval is an associative array, then assume it's the trace span initialization
- *   options
- * - if the zval is an array that looks like a callable, then assume it's a callable
- * - if the zval is a Closure, then execute the closure and take the results as
- *   the trace span initialization options
- */
-static void opencensus_trace_execute_callback(opencensus_trace_span_t *span, zend_execute_data *execute_data, zval *span_options TSRMLS_DC)
-{
-    zend_string *callback_name = NULL;
-    if (zend_is_callable(span_options, 0, &callback_name)) {
-        zval callback_result;
-        if (opencensus_trace_call_user_function_callback(execute_data, span, span_options, &callback_result TSRMLS_CC) == SUCCESS) {
-            opencensus_trace_span_apply_span_options(span, &callback_result);
-        }
-        ZVAL_DESTRUCTOR(&callback_result);
-    } else if (Z_TYPE_P(span_options) == IS_ARRAY) {
-        opencensus_trace_span_apply_span_options(span, span_options);
-    }
-    zend_string_release(callback_name);
 }
 
 /**
@@ -619,9 +604,23 @@ void opencensus_trace_execute_ex (zend_execute_data *execute_data TSRMLS_DC) {
         trace_handler = zend_hash_find(OPENCENSUS_TRACE_G(user_traced_functions), function_name);
 
         if (trace_handler != NULL) {
+            zend_string *callback_name = NULL;
             span = opencensus_trace_begin(function_name, execute_data, NULL TSRMLS_CC);
-            opencensus_original_zend_execute_ex(execute_data TSRMLS_CC);
-            opencensus_trace_execute_callback(span, execute_data, trace_handler TSRMLS_CC);
+
+            if (zend_is_callable(trace_handler, 0, &callback_name)) {
+                zval callback_result;
+                zval *args;
+                int num_args;
+                opencensus_copy_args(execute_data, &args, &num_args);
+                opencensus_original_zend_execute_ex(execute_data TSRMLS_CC);
+                if (opencensus_trace_call_user_function_callback(args, num_args, execute_data, span, trace_handler, &callback_result TSRMLS_CC) == SUCCESS) {
+                    opencensus_trace_span_apply_span_options(span, &callback_result);
+                }
+                opencensus_free_args(args, num_args);
+            } else {
+                opencensus_original_zend_execute_ex(execute_data TSRMLS_CC);
+                opencensus_trace_span_apply_span_options(span, trace_handler);
+            }
             opencensus_trace_finish();
         } else {
             opencensus_original_zend_execute_ex(execute_data TSRMLS_CC);
@@ -657,14 +656,29 @@ void opencensus_trace_execute_internal(INTERNAL_FUNCTION_PARAMETERS)
     );
     zval *trace_handler;
     opencensus_trace_span_t *span;
+    zend_string *callback_name = NULL;
 
     if (function_name) {
         trace_handler = zend_hash_find(OPENCENSUS_TRACE_G(user_traced_functions), function_name);
 
         if (trace_handler) {
+            zend_string *callback_name = NULL;
             span = opencensus_trace_begin(function_name, execute_data, NULL TSRMLS_CC);
-            resume_execute_internal(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-            opencensus_trace_execute_callback(span, execute_data, trace_handler TSRMLS_CC);
+
+            if (zend_is_callable(trace_handler, 0, &callback_name)) {
+                zval callback_result;
+                zval *args;
+                int num_args;
+                opencensus_copy_args(execute_data, &args, &num_args);
+                resume_execute_internal(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+                if (opencensus_trace_call_user_function_callback(args, num_args, execute_data, span, trace_handler, &callback_result TSRMLS_CC) == SUCCESS) {
+                    opencensus_trace_span_apply_span_options(span, &callback_result);
+                }
+                opencensus_free_args(args, num_args);
+            } else {
+                resume_execute_internal(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+                opencensus_trace_span_apply_span_options(span, trace_handler);
+            }
             opencensus_trace_finish();
         } else {
             resume_execute_internal(INTERNAL_FUNCTION_PARAM_PASSTHRU);

--- a/ext/tests/function_callback_arguments_array.phpt
+++ b/ext/tests/function_callback_arguments_array.phpt
@@ -1,0 +1,35 @@
+--TEST--
+OpenCensus Trace: Function callback closure that reads array arguments
+--FILE--
+<?php
+
+function func1($n)
+{
+    return $n;
+}
+
+opencensus_trace_function('func1', function ($n) {
+    var_dump($n);
+    return [
+        'attributes' => [
+            'n' => count($n)
+        ]
+    ];
+});
+
+$result = func1([1,2,3]);
+echo "Result: " . implode(',', $result) . PHP_EOL;
+
+$spans = opencensus_trace_list();
+echo "Number of spans: " . count($spans) . "\n";
+$span = $spans[0];
+
+print_r($span->attributes());
+?>
+--EXPECT--
+Result: 1,2,3
+Number of spans: 1
+Array
+(
+    [n] => 3
+)

--- a/ext/tests/function_callback_arguments_array.phpt
+++ b/ext/tests/function_callback_arguments_array.phpt
@@ -9,7 +9,6 @@ function func1($n)
 }
 
 opencensus_trace_function('func1', function ($n) {
-    var_dump($n);
     return [
         'attributes' => [
             'n' => count($n)

--- a/ext/tests/function_callback_arguments_string.phpt
+++ b/ext/tests/function_callback_arguments_string.phpt
@@ -1,0 +1,34 @@
+--TEST--
+OpenCensus Trace: Customize the trace span options for a function with a callback closure that reads string arguments
+--FILE--
+<?php
+
+function func1($n)
+{
+    return $n;
+}
+
+opencensus_trace_function('func1', function ($n) {
+    return [
+        'attributes' => [
+            'n' => $n
+        ]
+    ];
+});
+
+$result = func1('hello');
+echo "Result: $result" . PHP_EOL;
+
+$spans = opencensus_trace_list();
+echo "Number of spans: " . count($spans) . "\n";
+$span = $spans[0];
+
+print_r($span->attributes());
+?>
+--EXPECT--
+Result: hello
+Number of spans: 1
+Array
+(
+    [n] => hello
+)

--- a/ext/tests/method_callback_arguments_array.phpt
+++ b/ext/tests/method_callback_arguments_array.phpt
@@ -1,0 +1,39 @@
+--TEST--
+OpenCensus Trace: Method callback closure that reads array arguments
+--FILE--
+<?php
+
+class TestClass
+{
+    public function func1($n)
+    {
+        return $n;
+    }
+}
+
+opencensus_trace_method(TestClass::class, 'func1', function ($obj, $n) {
+var_dump($n);
+    return [
+        'attributes' => [
+            'n' => count($n)
+        ]
+    ];
+});
+
+$obj = new TestClass();
+$result = $obj->func1([1,2,3]);
+echo "Result: " . implode(',', $result) . PHP_EOL;
+
+$spans = opencensus_trace_list();
+echo "Number of spans: " . count($spans) . "\n";
+$span = $spans[0];
+
+print_r($span->attributes());
+?>
+--EXPECT--
+Result: 1,2,3
+Number of spans: 1
+Array
+(
+    [n] => 3
+)

--- a/ext/tests/method_callback_arguments_array.phpt
+++ b/ext/tests/method_callback_arguments_array.phpt
@@ -12,7 +12,6 @@ class TestClass
 }
 
 opencensus_trace_method(TestClass::class, 'func1', function ($obj, $n) {
-var_dump($n);
     return [
         'attributes' => [
             'n' => count($n)

--- a/ext/tests/method_callback_arguments_string.phpt
+++ b/ext/tests/method_callback_arguments_string.phpt
@@ -1,0 +1,38 @@
+--TEST--
+OpenCensus Trace: Customize the trace span options for a function with a callback closure that reads string arguments
+--FILE--
+<?php
+
+class TestClass
+{
+    public function func1($n)
+    {
+        return $n;
+    }
+}
+
+opencensus_trace_method(TestClass::class, 'func1', function ($obj, $n) {
+    return [
+        'attributes' => [
+            'n' => $n
+        ]
+    ];
+});
+
+$obj = new TestClass();
+$result = $obj->func1('hello');
+echo "Result: $result" . PHP_EOL;
+
+$spans = opencensus_trace_list();
+echo "Number of spans: " . count($spans) . "\n";
+$span = $spans[0];
+
+print_r($span->attributes());
+?>
+--EXPECT--
+Result: hello
+Number of spans: 1
+Array
+(
+    [n] => hello
+)


### PR DESCRIPTION
Currently, we are running the watched function callback after executing the traced function which is desired because you can access information about the results of the function (e.g. how many bytes sent/received from a curl request). However, it's possible for the arguments to be deallocated by the memory manager after execution. This can cause undefined behavior (potentially segfaults).

We will instead copy the argument argument zvals before executing the original function, then provide those copies to the callback function.

May fix #183 