### PR TITLE
Prepare 0.5.1

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -22,5 +22,5 @@ namespace OpenCensus;
  */
 class Version
 {
-    const VERSION = '0.4.3';
+    const VERSION = '0.5.1';
 }


### PR DESCRIPTION
* Memcache extension integration removed - Memcache extension requires PHP < 7 and OpenCensus extension requires PHP >= 7 (#182)
* Added static methods to global tracer for adding attributes, time events (#178)
* Guzzle extension integration removed - Guzzle Middleware/EventSubscriber should be used (#188)
* Fixed handling of large decimal span ids in `CloudTraceFormat` for span context propagation (#192)