### PR TITLE
Only set status of the root span on exit if an HTTP response code has been set

### DIFF
--- a/src/Trace/RequestHandler.php
+++ b/src/Trace/RequestHandler.php
@@ -261,8 +261,9 @@ class RequestHandler
 
     public function addCommonRequestAttributes(array $headers)
     {
-        $responseCode = http_response_code();
-        $this->rootSpan->setStatus($responseCode, "HTTP status code: $responseCode");
+        if ($responseCode = http_response_code()) {
+            $this->rootSpan->setStatus($responseCode, "HTTP status code: $responseCode");
+        }
         $this->tracer->addAttribute(Span::ATTRIBUTE_STATUS_CODE, $responseCode, [
             'spanId' => $this->rootSpan->spanId()
         ]);

--- a/src/Trace/RequestHandler.php
+++ b/src/Trace/RequestHandler.php
@@ -263,10 +263,10 @@ class RequestHandler
     {
         if ($responseCode = http_response_code()) {
             $this->rootSpan->setStatus($responseCode, "HTTP status code: $responseCode");
+            $this->tracer->addAttribute(Span::ATTRIBUTE_STATUS_CODE, $responseCode, [
+                'spanId' => $this->rootSpan->spanId()
+            ]);
         }
-        $this->tracer->addAttribute(Span::ATTRIBUTE_STATUS_CODE, $responseCode, [
-            'spanId' => $this->rootSpan->spanId()
-        ]);
         foreach (self::ATTRIBUTE_MAP as $attributeKey => $headerKeys) {
             if ($val = $this->detectKey($headerKeys, $headers)) {
                 $this->tracer->addAttribute($attributeKey, $val, [

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -687,6 +687,7 @@ class RequestHandlerTest extends TestCase
         $this->assertInstanceOf(SpanData::class, $spanData);
         $this->assertNotEmpty($spanData->endTime());
         $this->assertEquals('main', $spanData->name());
+        $this->assertEquals([], $spanData->attributes());
         $this->assertNull($spanData->status());
     }
 
@@ -709,7 +710,13 @@ class RequestHandlerTest extends TestCase
         $this->assertInstanceOf(SpanData::class, $spanData);
         $this->assertNotEmpty($spanData->endTime());
         $this->assertEquals('main', $spanData->name());
-        $this->assertInstanceOf(Status::class, $spanData->status());
-        $this->assertEquals(200, $spanData->status()->code());
+        $this->assertEquals([Span::ATTRIBUTE_STATUS_CODE => 200], $spanData->attributes());
+
+        if (extension_loaded('opencensus')) {
+            $this->assertNull($spanData->status());
+        } else {
+            $this->assertInstanceOf(Status::class, $spanData->status());
+            $this->assertEquals(200, $spanData->status()->code());
+        }
     }
 }

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -17,17 +17,21 @@
 
 namespace OpenCensus\Tests\Unit\Trace;
 
+require_once __DIR__ . '/mock_http_response_code.php';
+
 use OpenCensus\Trace\Annotation;
 use OpenCensus\Trace\Link;
 use OpenCensus\Trace\MessageEvent;
 use OpenCensus\Trace\Span;
 use OpenCensus\Trace\SpanContext;
 use OpenCensus\Trace\SpanData;
+use OpenCensus\Trace\Status;
 use OpenCensus\Trace\RequestHandler;
 use OpenCensus\Trace\Exporter\ExporterInterface;
 use OpenCensus\Trace\Sampler\SamplerInterface;
 use OpenCensus\Trace\Tracer\NullTracer;
 use OpenCensus\Trace\Propagator\HttpHeaderPropagator;
+use OpenCensus\Trace\MockHttpResponseCode;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -662,5 +666,50 @@ class RequestHandlerTest extends TestCase
         $this->assertEquals('message-id', $messageEvent->id());
         $this->assertEquals(123, $messageEvent->compressedSize());
         $this->assertEquals(234, $messageEvent->uncompressedSize());
+    }
+
+    public function testNoStatusOfRootSpanOnExitWithoutHttpResponse()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        MockHttpResponseCode::$status = false;
+        $rt->onExit();
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(1, $spans);
+        $spanData = $spans[0];
+        $this->assertInstanceOf(SpanData::class, $spanData);
+        $this->assertNotEmpty($spanData->endTime());
+        $this->assertEquals('main', $spanData->name());
+        $this->assertNull($spanData->status());
+    }
+
+    public function testSetsStatusOfRootSpanOnExitWithHttpResponse()
+    {
+        $this->sampler->shouldSample()->willReturn(true);
+        $rt = new RequestHandler(
+            $this->exporter->reveal(),
+            $this->sampler->reveal(),
+            new HttpHeaderPropagator(),
+            [
+                'skipReporting' => true
+            ]
+        );
+        MockHttpResponseCode::$status = 200;
+        $rt->onExit();
+        $spans = $rt->tracer()->spans();
+        $this->assertCount(1, $spans);
+        $spanData = $spans[0];
+        $this->assertInstanceOf(SpanData::class, $spanData);
+        $this->assertNotEmpty($spanData->endTime());
+        $this->assertEquals('main', $spanData->name());
+        $this->assertInstanceOf(Status::class, $spanData->status());
+        $this->assertEquals(200, $spanData->status()->code());
     }
 }

--- a/tests/unit/Trace/mock_http_response_code.php
+++ b/tests/unit/Trace/mock_http_response_code.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright 2018 OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace OpenCensus\Trace;
+
+/**
+ * A mock function for testing the http_response_code function.
+ * See http://us2.php.net/manual/en/function.http-response-code.php
+ */
+
+function http_response_code($status = 0)
+{
+    if (php_sapi_name() === 'cli') {
+        if ($status) {
+            MockHttpResponseCode::$status = $status;
+            return true;
+        } else {
+            return MockHttpResponseCode::$status ?: false;
+        }
+    } else {
+        $last_status = MockHttpResponseCode::$status ?: 200;
+        if ($status) {
+            MockHttpResponseCode::$status = $status;
+        }
+        return $last_status;
+    }
+}
+
+/**
+ * A class for overriding the return value of the mocked http_response_code function.
+ */
+
+class MockHttpResponseCode
+{
+    public static $status = null;
+}


### PR DESCRIPTION
Hi!

I'd like to contribute a fix to prevent an invalid Status from being set on the root span when there is no available HTTP response code. When OpenCensus is used in a CLI context with the StackdriverExporter, the Stackdriver Trace API rejects the `false` status code (returned by `http_response_code`) as invalid.