### PR TITLE
Make NullTracer pass spanOptions to constructor

### DIFF
--- a/src/Trace/Tracer/NullTracer.php
+++ b/src/Trace/Tracer/NullTracer.php
@@ -52,7 +52,7 @@ class NullTracer implements TracerInterface
      */
     public function startSpan(array $spanOptions)
     {
-        return new Span();
+        return new Span($spanOptions);
     }
 
     /**


### PR DESCRIPTION
Passing in the provided $spanOptions helps reduce the time and memory usage of requests that use the NullTracer. In instrumented code calling startSpan, the `name` may already be set, and a user might provide a filtered or empty `stackTrace` value.

This makes things more consistent, since it was surprising that non-sampled requests were calling and looping through debug_backtrace when sampled requests were not.