### PR TITLE
Prepare 0.5.2

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -22,5 +22,5 @@ namespace OpenCensus;
  */
 class Version
 {
-    const VERSION = '0.5.1';
+    const VERSION = '0.5.2';
 }


### PR DESCRIPTION
- Only set status of the root span on exit if an HTTP response code has been set (#194)
- Make NullTracer pass spanOptions to constructor (#202)