### PR TITLE
improved opencensus-php dockerfile adding composer+git for easy usage

### DIFF
--- a/ext/docker/Dockerfile.PHP7.3-apache
+++ b/ext/docker/Dockerfile.PHP7.3-apache
@@ -1,5 +1,7 @@
 FROM php:7.3-apache
 
+VOLUME /var/www
+
 COPY config.m4 opencensus*.c opencensus*.h php_opencensus.h varint.* /tmp/opencensus/
 
 RUN cd /tmp/opencensus \
@@ -9,7 +11,9 @@ RUN cd /tmp/opencensus \
     && make install \
     && cd ~ \
     && rm -r /tmp/opencensus \
-    && docker-php-ext-enable opencensus
+    && docker-php-ext-enable opencensus \
+    && apt-get update && apt-get install -y git unzip && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/www/html \
+    && sh -c "curl -sS https://getcomposer.org/installer | php  -- --install-dir=/usr/local/bin --filename=composer"
 
-VOLUME /tmp
-VOLUME /var/www/html
+WORKDIR /var/www


### PR DESCRIPTION
Adds `composer` to docker image making it easy to work with a composer project straight from the image using a mounted volume. 

Example of this can be found here: https://github.com/basvanbeek/opencensus-php-docker