### PR TITLE
Using PHP 7.1 types

### DIFF
--- a/src/Core/Context.php
+++ b/src/Core/Context.php
@@ -51,7 +51,7 @@ class Context
      *
      * @param array $initialValues
      */
-    public function __construct($initialValues = [])
+    public function __construct(array $initialValues = [])
     {
         $this->values = $initialValues;
     }
@@ -63,7 +63,7 @@ class Context
      * @param mixed $value
      * @return Context
      */
-    public function withValue($key, $value)
+    public function withValue(string $key, $value): Context
     {
         $copy = $this->values;
         $copy[$key] = $value;
@@ -76,7 +76,7 @@ class Context
      * @param array $data
      * @return Context
      */
-    public function withValues($data)
+    public function withValues(array $data): Context
     {
         $copy = $this->values;
         foreach ($data as $key => $value) {
@@ -93,7 +93,7 @@ class Context
      * @param mixed $default [optional]
      * @return mixed
      */
-    public function value($key, $default = null)
+    public function value(string $key, $default = null)
     {
         return array_key_exists($key, $this->values)
             ? $this->values[$key]
@@ -105,7 +105,7 @@ class Context
      *
      * @return array
      */
-    public function values()
+    public function values(): array
     {
         return $this->values;
     }
@@ -116,7 +116,7 @@ class Context
      *
      * @return Context
      */
-    public function attach()
+    public function attach(): Context
     {
         $current = self::current();
         self::$current = $this;
@@ -144,7 +144,7 @@ class Context
      *
      * @return Context
      */
-    public static function current()
+    public static function current(): Context
     {
         if (!self::$current) {
             self::$current = self::background();
@@ -158,7 +158,7 @@ class Context
      *
      * @return Context
      */
-    public static function background()
+    public static function background(): Context
     {
         return new Context();
     }

--- a/src/Core/DaemonClient.php
+++ b/src/Core/DaemonClient.php
@@ -298,7 +298,7 @@ class DaemonClient implements StatsExporter, TraceExporter
         return self::$instance->send(self::MSG_STATS_RECORD, $msg);
     }
 
-    public function export(array $spans)
+    public function export(array $spans): bool
     {
         $spanData = json_encode(array_map(function (SpanData $span) {
             return [

--- a/src/Core/Scope.php
+++ b/src/Core/Scope.php
@@ -49,7 +49,7 @@ class Scope
      * @param callable $callback
      * @param array $args
      */
-    public function __construct(callable $callback, $args = [])
+    public function __construct(callable $callback, array $args = [])
     {
         $this->callback = $callback;
         $this->args = $args;
@@ -58,7 +58,7 @@ class Scope
     /**
      * Close and clean up the scope. Runs the initial callback provided.
      */
-    public function close()
+    public function close(): void
     {
         call_user_func_array($this->callback, $this->args);
     }

--- a/src/Stats/Stats.php
+++ b/src/Stats/Stats.php
@@ -104,7 +104,7 @@ class Stats
      *
      * @param ExporterInterface $exporter
      */
-    public static function setExporter(ExporterInterface $exporter)
+    public static function setExporter(ExporterInterface $exporter): void
     {
         self::getInstance()->exporter = $exporter;
     }

--- a/src/Tags/TagContext.php
+++ b/src/Tags/TagContext.php
@@ -106,7 +106,7 @@ class TagContext
      * @param TagKey $key key of the Tag.
      * @param TagValue $value value of the Tag.
      */
-    final public function upsert(TagKey $key, TagValue $value)
+    final public function upsert(TagKey $key, TagValue $value): void
     {
         $this->m[$key->getName()] = new Tag($key, $value);
     }

--- a/src/Trace/Annotation.php
+++ b/src/Trace/Annotation.php
@@ -38,7 +38,7 @@ class Annotation extends TimeEvent
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function __construct($description, $options = [])
+    public function __construct(string $description, array $options = [])
     {
         parent::__construct($options);
         $this->description = $description;
@@ -52,7 +52,7 @@ class Annotation extends TimeEvent
      *
      * @return string
      */
-    public function description()
+    public function description(): string
     {
         return $this->description;
     }

--- a/src/Trace/AttributeTrait.php
+++ b/src/Trace/AttributeTrait.php
@@ -29,7 +29,7 @@ trait AttributeTrait
      *
      * @param array $attributes Attributes in the form of $attribute => $value
      */
-    public function addAttributes(array $attributes)
+    public function addAttributes(array $attributes): void
     {
         foreach ($attributes as $attribute => $value) {
             $this->addAttribute($attribute, $value);
@@ -42,9 +42,9 @@ trait AttributeTrait
      * @param string $attribute The name of the attribute.
      * @param mixed $value The value of the attribute. Will be cast to a string
      */
-    public function addAttribute($attribute, $value)
+    public function addAttribute(string $attribute, string $value): void
     {
-        $this->attributes[$attribute] = (string) $value;
+        $this->attributes[$attribute] = $value;
     }
 
     /**
@@ -52,7 +52,7 @@ trait AttributeTrait
      *
      * @return array
      */
-    public function attributes()
+    public function attributes(): array
     {
         return $this->attributes;
     }

--- a/src/Trace/DateFormatTrait.php
+++ b/src/Trace/DateFormatTrait.php
@@ -30,7 +30,7 @@ trait DateFormatTrait
      * @return \DateTimeInterface
      * @throws \InvalidArgumentException
      */
-    private function formatDate($when = null)
+    private function formatDate($when = null): \DateTimeInterface
     {
         if (!$when) {
             // now
@@ -50,7 +50,7 @@ trait DateFormatTrait
      * @param float $when The Unix timestamp to be converted.
      * @return \DateTimeInterface
      */
-    private function formatFloatTimeToDate($when)
+    private function formatFloatTimeToDate($when): \DateTimeInterface
     {
         return \DateTime::createFromFormat('U.u', number_format($when, 6, '.', ''));
     }

--- a/src/Trace/EventHandler/NullEventHandler.php
+++ b/src/Trace/EventHandler/NullEventHandler.php
@@ -2,9 +2,7 @@
 
 namespace OpenCensus\Trace\EventHandler;
 
-use OpenCensus\Trace\Annotation;
 use OpenCensus\Trace\Link;
-use OpenCensus\Trace\MessageEvent;
 use OpenCensus\Trace\Span;
 use OpenCensus\Trace\TimeEvent;
 
@@ -20,7 +18,7 @@ class NullEventHandler implements SpanEventHandlerInterface
      * @param string $attribute The name of the attribute added
      * @param string $value The attribute value
      */
-    public function attributeAdded(Span $span, $attribute, $value)
+    public function attributeAdded(Span $span, string $attribute, string $value): void
     {
     }
 
@@ -30,7 +28,7 @@ class NullEventHandler implements SpanEventHandlerInterface
      * @param Span $span The span the link was added to
      * @param Link $link The link added to the span
      */
-    public function linkAdded(Span $span, Link $link)
+    public function linkAdded(Span $span, Link $link): void
     {
     }
 
@@ -40,7 +38,7 @@ class NullEventHandler implements SpanEventHandlerInterface
      * @param Span $span The span the time event was added to
      * @param TimeEvent $timeEvent The time event added to the span
      */
-    public function timeEventAdded(Span $span, TimeEvent $timeEvent)
+    public function timeEventAdded(Span $span, TimeEvent $timeEvent): void
     {
     }
 }

--- a/src/Trace/EventHandler/SpanEventHandlerInterface.php
+++ b/src/Trace/EventHandler/SpanEventHandlerInterface.php
@@ -18,7 +18,7 @@ interface SpanEventHandlerInterface
      * @param string $attribute The name of the attribute added
      * @param string $value The attribute value
      */
-    public function attributeAdded(Span $span, $attribute, $value);
+    public function attributeAdded(Span $span, string $attribute, string $value): void;
 
     /**
      * Triggers when a link is added to a span.
@@ -26,7 +26,7 @@ interface SpanEventHandlerInterface
      * @param Span $span The span the link was added to
      * @param Link $link The link added to the span
      */
-    public function linkAdded(Span $span, Link $link);
+    public function linkAdded(Span $span, Link $link): void;
 
     /**
      * Triggers when a time event is added to a span.
@@ -34,5 +34,5 @@ interface SpanEventHandlerInterface
      * @param Span $span The span the time event was added to
      * @param TimeEvent $timeEvent The time event added to the span
      */
-    public function timeEventAdded(Span $span, TimeEvent $timeEvent);
+    public function timeEventAdded(Span $span, TimeEvent $timeEvent): void;
 }

--- a/src/Trace/Exporter/EchoExporter.php
+++ b/src/Trace/Exporter/EchoExporter.php
@@ -40,7 +40,7 @@ class EchoExporter implements ExporterInterface
      * @param SpanData[] $spans
      * @return bool
      */
-    public function export(array $spans)
+    public function export(array $spans): bool
     {
         print_r($spans);
         return true;

--- a/src/Trace/Exporter/ExporterInterface.php
+++ b/src/Trace/Exporter/ExporterInterface.php
@@ -30,5 +30,5 @@ interface ExporterInterface
      * @param SpanData[] $spans
      * @return bool
      */
-    public function export(array $spans);
+    public function export(array $spans): bool;
 }

--- a/src/Trace/Exporter/FileExporter.php
+++ b/src/Trace/Exporter/FileExporter.php
@@ -45,7 +45,7 @@ class FileExporter implements ExporterInterface
      *
      * @param string $filename The path to the output file.
      */
-    public function __construct($filename)
+    public function __construct(string $filename)
     {
         $this->filename = $filename;
     }
@@ -56,7 +56,7 @@ class FileExporter implements ExporterInterface
      * @param SpanData[] $spans
      * @return bool
      */
-    public function export(array $spans)
+    public function export(array $spans): bool
     {
         $spans = $this->convertSpans($spans);
         return file_put_contents($this->filename, json_encode($spans) . PHP_EOL, FILE_APPEND) !== false;
@@ -68,7 +68,7 @@ class FileExporter implements ExporterInterface
      * @param SpanData[] $spans
      * @return array Representation of the collected trace spans ready for serialization
      */
-    private function convertSpans(array $spans)
+    private function convertSpans(array $spans): array
     {
         return array_map(function (SpanData $span) {
             return [

--- a/src/Trace/Exporter/LoggerExporter.php
+++ b/src/Trace/Exporter/LoggerExporter.php
@@ -56,7 +56,7 @@ class LoggerExporter implements ExporterInterface
      * @param LoggerInterface $logger The logger to write to.
      * @param string $level The logger level to write as. **Defaults to** `notice`.
      */
-    public function __construct(LoggerInterface $logger, $level = self::DEFAULT_LOG_LEVEL)
+    public function __construct(LoggerInterface $logger, string $level = self::DEFAULT_LOG_LEVEL)
     {
         $this->logger = $logger;
         $this->level = $level;
@@ -68,7 +68,7 @@ class LoggerExporter implements ExporterInterface
      * @param SpanData[] $spans
      * @return bool
      */
-    public function export(array $spans)
+    public function export(array $spans): bool
     {
         try {
             $this->logger->log($this->level, json_encode($spans));

--- a/src/Trace/Exporter/NullExporter.php
+++ b/src/Trace/Exporter/NullExporter.php
@@ -17,6 +17,7 @@
 
 namespace OpenCensus\Trace\Exporter;
 
+use OpenCensus\Trace\SpanData;
 use OpenCensus\Trace\Tracer\TracerInterface;
 
 /**
@@ -39,7 +40,7 @@ class NullExporter implements ExporterInterface
      * @param SpanData[] $spans
      * @return bool
      */
-    public function export(array $spans)
+    public function export(array $spans): bool
     {
         return true;
     }

--- a/src/Trace/Exporter/OneLineEchoExporter.php
+++ b/src/Trace/Exporter/OneLineEchoExporter.php
@@ -28,7 +28,7 @@ class OneLineEchoExporter implements ExporterInterface
      * @param SpanData[] $spans
      * @return bool
      */
-    public function export(array $spans)
+    public function export(array $spans): bool
     {
         foreach ($spans as $span) {
             $time = (float) ($span->endTime()->format('U.u')) - (float) ($span->startTime()->format('U.u'));

--- a/src/Trace/IdGeneratorTrait.php
+++ b/src/Trace/IdGeneratorTrait.php
@@ -29,7 +29,7 @@ trait IdGeneratorTrait
      *
      * @return string
      */
-    private function generateTraceId()
+    private function generateTraceId(): string
     {
         return str_replace('-', '', Uuid::uuid4());
     }

--- a/src/Trace/Integrations/Curl.php
+++ b/src/Trace/Integrations/Curl.php
@@ -34,7 +34,7 @@ class Curl implements IntegrationInterface
     /**
      * Static method to add instrumentation to curl requests
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load curl integrations.', E_USER_WARNING);
@@ -53,7 +53,7 @@ class Curl implements IntegrationInterface
      * @param resource $resource The curl handler
      * @return array
      */
-    public static function handleCurlResource($resource)
+    public static function handleCurlResource($resource): array
     {
         return [
             'attributes' => [

--- a/src/Trace/Integrations/Doctrine.php
+++ b/src/Trace/Integrations/Doctrine.php
@@ -35,7 +35,7 @@ class Doctrine implements IntegrationInterface
     /**
      * Static method to add instrumentation to Doctrine ORM calls
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load Doctrine integrations.', E_USER_WARNING);

--- a/src/Trace/Integrations/Eloquent.php
+++ b/src/Trace/Integrations/Eloquent.php
@@ -36,7 +36,7 @@ class Eloquent implements IntegrationInterface
     /**
      * Static method to add instrumentation to Eloquent ORM calls
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load Eloquent integrations.', E_USER_WARNING);

--- a/src/Trace/Integrations/Grpc.php
+++ b/src/Trace/Integrations/Grpc.php
@@ -37,7 +37,7 @@ class Grpc implements IntegrationInterface
     /**
      * Static method to add instrumentation to grpc requests
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load grpc integrations.', E_USER_WARNING);
@@ -116,7 +116,7 @@ class Grpc implements IntegrationInterface
      * @param string $jwtAuthUri
      * @return array
      */
-    public static function updateMetadata($metadata, $jwtAuthUri)
+    public static function updateMetadata(array $metadata, string $jwtAuthUri): array
     {
         $context = Tracer::spanContext();
         if ($context->enabled()) {

--- a/src/Trace/Integrations/Guzzle/EventSubscriber.php
+++ b/src/Trace/Integrations/Guzzle/EventSubscriber.php
@@ -83,7 +83,7 @@ class EventSubscriber implements SubscriberInterface
      *
      * @param BeforeEvent $event Event object emitted before a request is sent
      */
-    public function onBefore(BeforeEvent $event)
+    public function onBefore(BeforeEvent $event): void
     {
         $request = $event->getRequest();
         $context = Tracer::spanContext();
@@ -107,7 +107,7 @@ class EventSubscriber implements SubscriberInterface
      *
      * @param EndEvent $event A terminal event that is emitted when a request transaction has ended
      */
-    public function onEnd(EndEvent $event)
+    public function onEnd(EndEvent $event): void
     {
         $this->scope->close();
     }

--- a/src/Trace/Integrations/Guzzle/Middleware.php
+++ b/src/Trace/Integrations/Guzzle/Middleware.php
@@ -65,7 +65,7 @@ class Middleware
      * @param  callable $handler The next handler in the HandlerStack
      * @return callable
      */
-    public function __invoke(callable $handler)
+    public function __invoke(callable $handler): callable
     {
         return function (RequestInterface $request, $options) use ($handler) {
             $context = Tracer::spanContext();

--- a/src/Trace/Integrations/IntegrationInterface.php
+++ b/src/Trace/Integrations/IntegrationInterface.php
@@ -25,5 +25,5 @@ interface IntegrationInterface
     /**
      * Static method to add instrumentation to a framework or library
      */
-    public static function load();
+    public static function load(): void;
 }

--- a/src/Trace/Integrations/Laravel.php
+++ b/src/Trace/Integrations/Laravel.php
@@ -34,7 +34,7 @@ class Laravel implements IntegrationInterface
     /**
      * Static method to add instrumentation to the Laravel framework
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load Laravel integrations.', E_USER_WARNING);

--- a/src/Trace/Integrations/Memcached.php
+++ b/src/Trace/Integrations/Memcached.php
@@ -34,7 +34,7 @@ class Memcached implements IntegrationInterface
     /**
      * Static method to add instrumentation to memcache requests
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load Memcached integrations.', E_USER_WARNING);

--- a/src/Trace/Integrations/Mysql.php
+++ b/src/Trace/Integrations/Mysql.php
@@ -34,7 +34,7 @@ class Mysql implements IntegrationInterface
     /**
      * Static method to add instrumentation to mysql requests
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load mysqli integrations.', E_USER_WARNING);

--- a/src/Trace/Integrations/PDO.php
+++ b/src/Trace/Integrations/PDO.php
@@ -34,7 +34,7 @@ class PDO implements IntegrationInterface
     /**
      * Static method to add instrumentation to the PDO requests
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load PDO integrations.', E_USER_WARNING);
@@ -64,11 +64,11 @@ class PDO implements IntegrationInterface
      * Handle extracting the SQL query from the first argument
      *
      * @internal
-     * @param PDO $pdo The connectoin
+     * @param \PDO $pdo The connection
      * @param string $query The SQL query to extract
      * @return array
      */
-    public static function handleQuery($pdo, $query)
+    public static function handleQuery($pdo, string $query): array
     {
         return [
             'attributes' => ['query' => $query],
@@ -80,11 +80,11 @@ class PDO implements IntegrationInterface
      * Handle extracting the Data Source Name (DSN) from the constructor aruments to PDO
      *
      * @internal
-     * @param PDO $pdo
+     * @param \PDO $pdo
      * @param string $dsn The connection DSN
      * @return array
      */
-    public static function handleConnect($pdo, $dsn)
+    public static function handleConnect($pdo, $dsn): array
     {
         return [
             'attributes' => ['dsn' => $dsn],
@@ -96,10 +96,10 @@ class PDO implements IntegrationInterface
      * Handle extracting the SQL query from a PDOStatement instance
      *
      * @internal
-     * @param PDOStatement $statement The prepared statement
+     * @param \PDOStatement $statement The prepared statement
      * @return array
      */
-    public static function handleStatementExecute($statement)
+    public static function handleStatementExecute($statement): array
     {
         return [
             'attributes' => ['query' => $statement->queryString],

--- a/src/Trace/Integrations/Postgres.php
+++ b/src/Trace/Integrations/Postgres.php
@@ -34,7 +34,7 @@ class Postgres implements IntegrationInterface
     /**
      * Static method to add instrumentation to the postgres requests
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load pg integrations.', E_USER_WARNING);

--- a/src/Trace/Integrations/Symfony.php
+++ b/src/Trace/Integrations/Symfony.php
@@ -35,7 +35,7 @@ class Symfony implements IntegrationInterface
     /**
      * Static method to add instrumentation to the Symfony framework
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load Symfony integrations.', E_USER_WARNING);

--- a/src/Trace/Integrations/Wordpress.php
+++ b/src/Trace/Integrations/Wordpress.php
@@ -32,7 +32,7 @@ class Wordpress implements IntegrationInterface
     /**
      * Static method to add instrumentation to the Wordpress framework
      */
-    public static function load()
+    public static function load(): void
     {
         if (!extension_loaded('opencensus')) {
             trigger_error('opencensus extension required to load Wordpress integrations.', E_USER_WARNING);

--- a/src/Trace/Link.php
+++ b/src/Trace/Link.php
@@ -57,7 +57,7 @@ class Link
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function __construct($traceId, $spanId, $options = [])
+    public function __construct(string $traceId, string $spanId, array $options = [])
     {
         $options += [
             'type' => self::TYPE_UNSPECIFIED,
@@ -74,7 +74,7 @@ class Link
      *
      * @return string
      */
-    public function traceId()
+    public function traceId(): string
     {
         return $this->traceId;
     }
@@ -84,7 +84,7 @@ class Link
      *
      * @return string
      */
-    public function spanId()
+    public function spanId(): string
     {
         return $this->spanId;
     }
@@ -94,7 +94,7 @@ class Link
      *
      * @return string
      */
-    public function type()
+    public function type(): string
     {
         return $this->type;
     }

--- a/src/Trace/MessageEvent.php
+++ b/src/Trace/MessageEvent.php
@@ -69,7 +69,7 @@ class MessageEvent extends TimeEvent
      *            uncompressed.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function __construct($type, $id, $options = [])
+    public function __construct(string $type, string $id, array $options = [])
     {
         $options += [
             'uncompressedSize' => null,
@@ -87,7 +87,7 @@ class MessageEvent extends TimeEvent
      *
      * @return string
      */
-    public function type()
+    public function type(): string
     {
         return $this->type;
     }
@@ -97,7 +97,7 @@ class MessageEvent extends TimeEvent
      *
      * @return string
      */
-    public function id()
+    public function id(): string
     {
         return $this->id;
     }
@@ -107,7 +107,7 @@ class MessageEvent extends TimeEvent
      *
      * @return int
      */
-    public function uncompressedSize()
+    public function uncompressedSize(): int
     {
         return $this->uncompressedSize;
     }
@@ -117,7 +117,7 @@ class MessageEvent extends TimeEvent
      *
      * @return int
      */
-    public function compressedSize()
+    public function compressedSize(): int
     {
         return $this->compressedSize;
     }

--- a/src/Trace/Propagator/BinaryFormatter.php
+++ b/src/Trace/Propagator/BinaryFormatter.php
@@ -37,9 +37,9 @@ class BinaryFormatter implements FormatterInterface
      * @param string $header
      * @return SpanContext
      */
-    public function deserialize($bin)
+    public function deserialize(string $header): SpanContext
     {
-        $data = @unpack('Cversion/Cfield0/H32traceId/Cfield1/H16spanId/Cfield2/Coptions', $bin);
+        $data = @unpack('Cversion/Cfield0/H32traceId/Cfield1/H16spanId/Cfield2/Coptions', $header);
         if ($data === false) {
             trigger_error('Invalid binary format for SpanContext', E_USER_WARNING);
             return new SpanContext();
@@ -57,7 +57,7 @@ class BinaryFormatter implements FormatterInterface
      * @param SpanContext $context
      * @return string
      */
-    public function serialize(SpanContext $context)
+    public function serialize(SpanContext $context): string
     {
         $spanHex = str_pad($context->spanId(), 16, "0", STR_PAD_LEFT);
         $traceOptions = $context->enabled() ? self::OPTION_ENABLED : 0;

--- a/src/Trace/Propagator/CloudTraceFormatter.php
+++ b/src/Trace/Propagator/CloudTraceFormatter.php
@@ -36,7 +36,7 @@ class CloudTraceFormatter implements FormatterInterface
      * @param string $header
      * @return SpanContext
      */
-    public function deserialize($header)
+    public function deserialize(string $header): SpanContext
     {
         if (preg_match(self::CONTEXT_HEADER_FORMAT, $header, $matches)) {
             return new SpanContext(
@@ -57,7 +57,7 @@ class CloudTraceFormatter implements FormatterInterface
      * @param SpanContext $context
      * @return string
      */
-    public function serialize(SpanContext $context)
+    public function serialize(SpanContext $context): string
     {
         $ret = '' . $context->traceId();
         if ($context->spanId()) {

--- a/src/Trace/Propagator/FormatterInterface.php
+++ b/src/Trace/Propagator/FormatterInterface.php
@@ -30,7 +30,7 @@ interface FormatterInterface
      * @param string $header
      * @return SpanContext
      */
-    public function deserialize($header);
+    public function deserialize(string $header): SpanContext;
 
     /**
      * Convert a SpanContext to header string
@@ -38,5 +38,5 @@ interface FormatterInterface
      * @param SpanContext $context
      * @return string
      */
-    public function serialize(SpanContext $context);
+    public function serialize(SpanContext $context): string;
 }

--- a/src/Trace/Propagator/GrpcMetadataPropagator.php
+++ b/src/Trace/Propagator/GrpcMetadataPropagator.php
@@ -58,7 +58,7 @@ class GrpcMetadataPropagator implements PropagatorInterface
      * @param array $metadata
      * @return SpanContext
      */
-    public function extract($metadata)
+    public function extract($metadata): SpanContext
     {
         if (array_key_exists($this->key, $metadata)) {
             return $this->formatter->deserialize($metadata[$this->key]);
@@ -73,7 +73,7 @@ class GrpcMetadataPropagator implements PropagatorInterface
      * @param array $container
      * @return array
      */
-    public function inject(SpanContext $context, $metadata)
+    public function inject(SpanContext $context, $metadata): array
     {
         $metadata[$this->key] = $this->formatter->serialize($context);
         return $metadata;
@@ -84,7 +84,7 @@ class GrpcMetadataPropagator implements PropagatorInterface
      *
      * @return FormatterInterface
      */
-    public function formatter()
+    public function formatter(): FormatterInterface
     {
         return $this->formatter;
     }
@@ -94,7 +94,7 @@ class GrpcMetadataPropagator implements PropagatorInterface
      *
      * @return string
      */
-    public function key()
+    public function key(): string
     {
         return $this->key;
     }

--- a/src/Trace/Propagator/HttpHeaderPropagator.php
+++ b/src/Trace/Propagator/HttpHeaderPropagator.php
@@ -58,7 +58,7 @@ class HttpHeaderPropagator implements PropagatorInterface
      * @param array $headers
      * @return SpanContext
      */
-    public function extract($headers)
+    public function extract($headers): SpanContext
     {
         if (array_key_exists($this->header, $headers)) {
             return $this->formatter->deserialize($headers[$this->header]);
@@ -73,7 +73,7 @@ class HttpHeaderPropagator implements PropagatorInterface
      * @param array $container
      * @return array
      */
-    public function inject(SpanContext $context, $container)
+    public function inject(SpanContext $context, $container): array
     {
         $header = $this->key();
         $value = $this->formatter->serialize($context);
@@ -90,7 +90,7 @@ class HttpHeaderPropagator implements PropagatorInterface
      *
      * @return FormatterInterface
      */
-    public function formatter()
+    public function formatter(): FormatterInterface
     {
         return $this->formatter;
     }
@@ -100,7 +100,7 @@ class HttpHeaderPropagator implements PropagatorInterface
      *
      * @return string
      */
-    public function key()
+    public function key(): string
     {
         return str_replace('_', '-', preg_replace('/^HTTP_/', '', $this->header));
     }

--- a/src/Trace/Propagator/PropagatorInterface.php
+++ b/src/Trace/Propagator/PropagatorInterface.php
@@ -32,7 +32,7 @@ interface PropagatorInterface
      * @param mixed $container
      * @return SpanContext
      */
-    public function extract($container);
+    public function extract($container): SpanContext;
 
     /**
      * Inject the SpanContext back into the response
@@ -41,19 +41,19 @@ interface PropagatorInterface
      * @param mixed $container
      * @return array
      */
-    public function inject(SpanContext $context, $container);
+    public function inject(SpanContext $context, $container): array;
 
     /**
      * Fetch the formatter for propagating the SpanContext
      *
      * @return FormatterInterface
      */
-    public function formatter();
+    public function formatter(): FormatterInterface;
 
     /**
      * Return the key used to propagate the SpanContext
      *
      * @return string
      */
-    public function key();
+    public function key(): string;
 }

--- a/src/Trace/Propagator/TraceContextFormatter.php
+++ b/src/Trace/Propagator/TraceContextFormatter.php
@@ -35,7 +35,7 @@ class TraceContextFormatter implements FormatterInterface
      * @param string $header
      * @return SpanContext
      */
-    public function deserialize($header)
+    public function deserialize(string $header): SpanContext
     {
         if (preg_match(self::CONTEXT_HEADER_FORMAT, $header, $matches)) {
             if ($matches[1] == "00") {
@@ -53,7 +53,7 @@ class TraceContextFormatter implements FormatterInterface
      * @param SpanContext $context
      * @return string
      */
-    public function serialize(SpanContext $context)
+    public function serialize(SpanContext $context): string
     {
         $ret = '00-' . $context->traceId();
         if ($context->spanId()) {
@@ -65,7 +65,7 @@ class TraceContextFormatter implements FormatterInterface
         return $ret;
     }
 
-    private function deserializeVersion0($header)
+    private function deserializeVersion0(string $header): ?SpanContext
     {
         if (preg_match(self::VERSION_0_FORMAT, $header, $matches)) {
             return new SpanContext(

--- a/src/Trace/RequestHandler.php
+++ b/src/Trace/RequestHandler.php
@@ -132,7 +132,7 @@ class RequestHandler
      * reports using the provided ExporterInterface. Adds additional attributes to
      * the root span detected from the response.
      */
-    public function onExit()
+    public function onExit(): void
     {
         $this->addCommonRequestAttributes($this->headers);
 
@@ -146,7 +146,7 @@ class RequestHandler
      *
      * @return TracerInterface
      */
-    public function tracer()
+    public function tracer(): TracerInterface
     {
         return $this->tracer;
     }
@@ -175,7 +175,7 @@ class RequestHandler
      *        <a href="Span.html#method___construct">OpenCensus\Trace\Span::__construct()</a>
      * @return Span
      */
-    public function startSpan(array $spanOptions = [])
+    public function startSpan(array $spanOptions = []): Span
     {
         return $this->tracer->startSpan($spanOptions);
     }
@@ -187,7 +187,7 @@ class RequestHandler
      * @param Span $span
      * @return Scope
      */
-    public function withSpan(Span $span)
+    public function withSpan(Span $span): Scope
     {
         return $this->tracer->withSpan($span);
     }
@@ -201,7 +201,7 @@ class RequestHandler
      *
      *      @type Span $span The span to add the attribute to.
      */
-    public function addAttribute($attribute, $value, $options = [])
+    public function addAttribute(string $attribute, string $value, array $options = []): void
     {
         $this->tracer->addAttribute($attribute, $value, $options);
     }
@@ -216,7 +216,7 @@ class RequestHandler
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addAnnotation($description, $options = [])
+    public function addAnnotation(string $description, array $options = []): void
     {
         $this->tracer->addAnnotation($description, $options);
     }
@@ -234,7 +234,7 @@ class RequestHandler
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addLink($traceId, $spanId, $options = [])
+    public function addLink(string $traceId, string $spanId, array $options = []): void
     {
         $this->tracer->addLink($traceId, $spanId, $options);
     }
@@ -254,12 +254,12 @@ class RequestHandler
      *            uncompressed.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addMessageEvent($type, $id, $options)
+    public function addMessageEvent(string $type, string $id, array $options): void
     {
         $this->tracer->addMessageEvent($type, $id, $options);
     }
 
-    public function addCommonRequestAttributes(array $headers)
+    public function addCommonRequestAttributes(array $headers): void
     {
         if ($responseCode = http_response_code()) {
             $this->rootSpan->setStatus($responseCode, "HTTP status code: $responseCode");
@@ -287,7 +287,7 @@ class RequestHandler
         return null;
     }
 
-    private function nameFromHeaders(array $headers)
+    private function nameFromHeaders(array $headers): string
     {
         if (array_key_exists('REQUEST_URI', $headers)) {
             return $headers['REQUEST_URI'];

--- a/src/Trace/Sampler/AlwaysSampleSampler.php
+++ b/src/Trace/Sampler/AlwaysSampleSampler.php
@@ -35,7 +35,7 @@ class AlwaysSampleSampler implements SamplerInterface
      *
      * @return bool
      */
-    public function shouldSample()
+    public function shouldSample(): bool
     {
         return true;
     }

--- a/src/Trace/Sampler/MultiSampler.php
+++ b/src/Trace/Sampler/MultiSampler.php
@@ -56,7 +56,7 @@ class MultiSampler implements SamplerInterface
      *
      * @return bool
      */
-    public function shouldSample()
+    public function shouldSample(): bool
     {
         foreach ($this->samplers as $sampler) {
             if ($sampler->shouldSample() === false) {

--- a/src/Trace/Sampler/NeverSampleSampler.php
+++ b/src/Trace/Sampler/NeverSampleSampler.php
@@ -35,7 +35,7 @@ class NeverSampleSampler implements SamplerInterface
      *
      * @return bool
      */
-    public function shouldSample()
+    public function shouldSample(): bool
     {
         return false;
     }

--- a/src/Trace/Sampler/ProbabilitySampler.php
+++ b/src/Trace/Sampler/ProbabilitySampler.php
@@ -39,9 +39,9 @@ class ProbabilitySampler implements SamplerInterface
     /**
      * Creates the ProbabilitySampler
      *
-     * @param float $percentage The percentage of requests to sample. Must be between 0 and 1.
+     * @param float $rate The percentage of requests to sample. Must be between 0 and 1.
      */
-    public function __construct($rate)
+    public function __construct(float $rate)
     {
         if ($rate > 1 || $rate < 0) {
             throw new \InvalidArgumentException('Percentage must be between 0 and 1');
@@ -55,7 +55,7 @@ class ProbabilitySampler implements SamplerInterface
      *
      * @return bool
      */
-    public function shouldSample()
+    public function shouldSample(): bool
     {
         return lcg_value() <= $this->rate;
     }
@@ -65,7 +65,7 @@ class ProbabilitySampler implements SamplerInterface
      *
      * @return float
      */
-    public function rate()
+    public function rate(): float
     {
         return $this->rate;
     }

--- a/src/Trace/Sampler/QpsSampler.php
+++ b/src/Trace/Sampler/QpsSampler.php
@@ -88,7 +88,7 @@ class QpsSampler implements SamplerInterface
      *     @type string $key The cache key to use. **Defaults to** `__opencensus_trace__`
      * }
      */
-    public function __construct(CacheItemPoolInterface $cache = null, $options = [])
+    public function __construct(CacheItemPoolInterface $cache = null, array $options = [])
     {
         $this->cache = $cache ?: $this->defaultCache();
         if (!$this->cache) {
@@ -118,7 +118,7 @@ class QpsSampler implements SamplerInterface
      *
      * @return bool
      */
-    public function shouldSample()
+    public function shouldSample(): bool
     {
         // We will store the microtime timestamp in the cache because some
         // cache implementations will not let you use expiry for anything less
@@ -143,7 +143,7 @@ class QpsSampler implements SamplerInterface
      *
      * @return CacheItemPoolInterface
      */
-    private function defaultCache()
+    private function defaultCache(): ?CacheItemPoolInterface
     {
         if (extension_loaded('apcu') && class_exists('\\Cache\\Adapter\\Apcu\\ApcuCachePool')) {
             return new \Cache\Adapter\Apcu\ApcuCachePool();
@@ -158,7 +158,7 @@ class QpsSampler implements SamplerInterface
      *
      * @return float
      */
-    public function rate()
+    public function rate(): float
     {
         return $this->rate;
     }

--- a/src/Trace/Sampler/SamplerInterface.php
+++ b/src/Trace/Sampler/SamplerInterface.php
@@ -27,5 +27,5 @@ interface SamplerInterface
      *
      * @return bool
      */
-    public function shouldSample();
+    public function shouldSample(): bool;
 }

--- a/src/Trace/Span.php
+++ b/src/Trace/Span.php
@@ -19,6 +19,7 @@ namespace OpenCensus\Trace;
 
 use OpenCensus\Trace\EventHandler\SpanEventHandler;
 use OpenCensus\Trace\EventHandler\NullEventHandler;
+use OpenCensus\Trace\EventHandler\SpanEventHandlerInterface;
 
 /**
  * This plain PHP class represents a single timed event within a Trace. Spans can
@@ -183,7 +184,7 @@ class Span
      *            belongs to the same process as the current span.
      *      @type string $kind The span's type.
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
         $options += [
             'traceId' => null,
@@ -245,7 +246,7 @@ class Span
      *         this span. **Defaults to** now. If provided as an int or float,
      *         it is expected to be a Unix timestamp.
      */
-    public function setStartTime($when = null)
+    public function setStartTime($when = null): void
     {
         $this->startTime = $this->formatDate($when);
     }
@@ -257,7 +258,7 @@ class Span
      *         this span. **Defaults to** now. If provided as an int or float,
      *         it is expected to be a Unix timestamp.
      */
-    public function setEndTime($when = null)
+    public function setEndTime($when = null): void
     {
         $this->endTime = $this->formatDate($when);
     }
@@ -267,7 +268,7 @@ class Span
      *
      * @return string
      */
-    public function spanId()
+    public function spanId(): string
     {
         return $this->spanId;
     }
@@ -277,7 +278,7 @@ class Span
      *
      * @return SpanData
      */
-    public function spanData()
+    public function spanData(): SpanData
     {
         return new SpanData(
             $this->name,
@@ -301,7 +302,7 @@ class Span
     /**
      * Mark this span as attached.
      */
-    public function attach()
+    public function attach(): void
     {
         $this->attached = true;
     }
@@ -311,7 +312,7 @@ class Span
      *
      * @return bool
      */
-    public function attached()
+    public function attached(): bool
     {
         return $this->attached;
     }
@@ -322,7 +323,7 @@ class Span
      * @param string $attribute The name of the attribute to add
      * @param string $value The attribute value
      */
-    public function addAttribute($attribute, $value)
+    public function addAttribute(string $attribute, string $value): void
     {
         $this->attributes[$attribute] = (string) $value;
         $this->eventHandler->attributeAdded($this, $attribute, $value);
@@ -333,7 +334,7 @@ class Span
      *
      * @param TimeEvent[] $timeEvents
      */
-    public function addTimeEvents(array $timeEvents)
+    public function addTimeEvents(array $timeEvents): void
     {
         foreach ($timeEvents as $timeEvent) {
             $this->addTimeEvent($timeEvent);
@@ -345,7 +346,7 @@ class Span
      *
      * @param TimeEvent $timeEvent
      */
-    public function addTimeEvent(TimeEvent $timeEvent)
+    public function addTimeEvent(TimeEvent $timeEvent): void
     {
         $this->timeEvents[] = $timeEvent;
         $this->eventHandler->timeEventAdded($this, $timeEvent);
@@ -356,7 +357,7 @@ class Span
      *
      * @param Link[] $links
      */
-    public function addLinks(array $links)
+    public function addLinks(array $links): void
     {
         foreach ($links as $link) {
             $this->addLink($link);
@@ -368,7 +369,7 @@ class Span
      *
      * @param Link $link
      */
-    public function addLink(Link $link)
+    public function addLink(Link $link): void
     {
         $this->links[] = $link;
         $this->eventHandler->linkAdded($this, $link);
@@ -380,7 +381,7 @@ class Span
      * @param int $code The status code
      * @param string $message A developer-facing error message
      */
-    public function setStatus($code, $message)
+    public function setStatus(int $code, string $message): void
     {
         $this->status = new Status($code, $message);
     }
@@ -391,7 +392,7 @@ class Span
      *
      * @return string
      */
-    private function generateSpanId()
+    private function generateSpanId(): string
     {
         return dechex(mt_rand());
     }
@@ -401,7 +402,7 @@ class Span
      *
      * @return array
      */
-    private function filterStackTrace($stackTrace)
+    private function filterStackTrace($stackTrace): array
     {
         return array_values(
             array_filter($stackTrace, function ($st) {
@@ -416,7 +417,7 @@ class Span
      *
      * @return string
      */
-    private function generateSpanName()
+    private function generateSpanName(): string
     {
         // Try to find the first stacktrace class entry that doesn't start with OpenCensus\Trace
         foreach ($this->stackTrace as $st) {

--- a/src/Trace/SpanContext.php
+++ b/src/Trace/SpanContext.php
@@ -17,8 +17,6 @@
 
 namespace OpenCensus\Trace;
 
-use OpenCensus\Core\Context;
-
 /**
  * SpanContext encapsulates your current context within your request's trace. It includes
  * 3 fields: the `traceId`, the current `spanId`, and an `enabled` flag which indicates whether
@@ -53,6 +51,11 @@ class SpanContext
     private $enabled;
 
     /**
+     * @var bool Whether or not the context was detected from an incoming header.
+     */
+    private $fromHeader;
+
+    /**
      * Creates a new SpanContext instance
      *
      * @param string $traceId The current traceId. If not set, one will be
@@ -63,8 +66,12 @@ class SpanContext
      * @param bool $fromHeader Whether or not the context was detected from an
      *        incoming header. **Defaults to** `false`.
      */
-    public function __construct($traceId = null, $spanId = null, $enabled = null, $fromHeader = false)
-    {
+    public function __construct(
+        string $traceId = null,
+        string $spanId = null,
+        bool $enabled = null,
+        bool $fromHeader = false
+    ) {
         $this->traceId = $traceId ?: $this->generateTraceId();
         $this->spanId = $spanId;
         $this->enabled = $enabled;
@@ -76,7 +83,7 @@ class SpanContext
      *
      * @return string
      */
-    public function traceId()
+    public function traceId(): string
     {
         return $this->traceId;
     }
@@ -84,9 +91,9 @@ class SpanContext
     /**
      * Fetch the current spanId.
      *
-     * @return string
+     * @return string|null
      */
-    public function spanId()
+    public function spanId(): ?string
     {
         return $this->spanId;
     }
@@ -96,7 +103,7 @@ class SpanContext
      *
      * @param string|null $spanId The spanId to set.
      */
-    public function setSpanId($spanId)
+    public function setSpanId(?string $spanId): void
     {
         $this->spanId = $spanId;
     }
@@ -104,9 +111,9 @@ class SpanContext
     /**
      * Whether or not the request is being traced.
      *
-     * @return bool
+     * @return bool|null
      */
-    public function enabled()
+    public function enabled(): ?bool
     {
         return $this->enabled;
     }
@@ -116,7 +123,7 @@ class SpanContext
      *
      * @param bool|null $enabled
      */
-    public function setEnabled($enabled)
+    public function setEnabled(?bool $enabled): void
     {
         $this->enabled = $enabled;
     }
@@ -126,7 +133,7 @@ class SpanContext
      *
      * @return bool
      */
-    public function fromHeader()
+    public function fromHeader(): bool
     {
         return $this->fromHeader;
     }

--- a/src/Trace/SpanData.php
+++ b/src/Trace/SpanData.php
@@ -46,7 +46,7 @@ class SpanData
      * The `spanId` of this span's parent span. If this is a root span, then
      * this field must be empty. 8-byte value encoded as a hex string.
      *
-     * @var string
+     * @var string|null
      */
     private $parentSpanId;
 
@@ -72,17 +72,16 @@ class SpanData
      * the local machine where the span execution starts. On the server side,
      * this is the time when the server's application handler starts running.
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      */
     private $startTime;
-
 
     /**
      * The end time of the span. On the client side, this is the time kept by
      * the local machine where the span execution ends. On the server side, this
      * is the time when the server application handler stops running.
      *
-     * @var \DateTimeInterface
+     * @var \DateTimeInterface|null
      */
     private $endTime;
 
@@ -114,7 +113,7 @@ class SpanData
     /**
      * An optional final status for this span.
      *
-     * @var Status
+     * @var Status|null
      */
     private $status;
 
@@ -123,7 +122,7 @@ class SpanData
      * crosses a process boundary. True when the parentSpanId belongs to the
      * same process as the current span.
      *
-     * @var bool
+     * @var bool|null
      */
     private $sameProcessAsParentSpan;
 
@@ -167,9 +166,9 @@ class SpanData
      *      @type string $kind The span's type.
      */
     public function __construct(
-        $name,
-        $traceId,
-        $spanId,
+        string $name,
+        string $traceId,
+        string $spanId,
         \DateTimeInterface $startTime = null,
         \DateTimeInterface $endTime = null,
         array $options = []
@@ -204,9 +203,9 @@ class SpanData
     /**
      * Retrieve the start time for this span.
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
-    public function startTime()
+    public function startTime(): ?\DateTimeInterface
     {
         return $this->startTime;
     }
@@ -214,9 +213,9 @@ class SpanData
     /**
      * Retrieve the end time for this span.
      *
-     * @return \DateTimeInterface
+     * @return \DateTimeInterface|null
      */
-    public function endTime()
+    public function endTime(): ?\DateTimeInterface
     {
         return $this->endTime;
     }
@@ -226,7 +225,7 @@ class SpanData
      *
      * @return string
      */
-    public function traceId()
+    public function traceId(): string
     {
         return $this->traceId;
     }
@@ -236,7 +235,7 @@ class SpanData
      *
      * @return string
      */
-    public function spanId()
+    public function spanId(): string
     {
         return $this->spanId;
     }
@@ -244,9 +243,9 @@ class SpanData
     /**
      * Retrieve the ID of this span's parent if it exists.
      *
-     * @return string
+     * @return string|null
      */
-    public function parentSpanId()
+    public function parentSpanId(): ?string
     {
         return $this->parentSpanId;
     }
@@ -254,9 +253,9 @@ class SpanData
     /**
      * Retrieve the name of this span.
      *
-     * @return string
+     * @return string|null
      */
-    public function name()
+    public function name(): string
     {
         return $this->name;
     }
@@ -266,7 +265,7 @@ class SpanData
      *
      * @return array
      */
-    public function attributes()
+    public function attributes(): array
     {
         return $this->attributes;
     }
@@ -276,7 +275,7 @@ class SpanData
      *
      * @return TimeEvent[]
      */
-    public function timeEvents()
+    public function timeEvents(): array
     {
         return $this->timeEvents;
     }
@@ -286,7 +285,7 @@ class SpanData
      *
      * @return Link[]
      */
-    public function links()
+    public function links(): array
     {
         return $this->links;
     }
@@ -294,9 +293,9 @@ class SpanData
     /**
      * Retrieve the final status for this span.
      *
-     * @return Status
+     * @return Status|null
      */
-    public function status()
+    public function status(): ?Status
     {
         return $this->status;
     }
@@ -306,7 +305,7 @@ class SpanData
      *
      * @return array
      */
-    public function stackTrace()
+    public function stackTrace(): array
     {
         return $this->stackTrace;
     }
@@ -316,7 +315,7 @@ class SpanData
      *
      * @return string
      */
-    public function stackTraceHashId()
+    public function stackTraceHashId(): string
     {
         if (!isset($this->stackTraceHashId)) {
             // take the lower 16 digits of the md5
@@ -331,7 +330,7 @@ class SpanData
      *
      * @return bool
      */
-    public function sameProcessAsParentSpan()
+    public function sameProcessAsParentSpan(): bool
     {
         return $this->sameProcessAsParentSpan;
     }
@@ -341,7 +340,7 @@ class SpanData
      *
      * @return string
      */
-    public function kind()
+    public function kind(): string
     {
         return $this->kind;
     }

--- a/src/Trace/Status.php
+++ b/src/Trace/Status.php
@@ -40,7 +40,7 @@ class Status
      * @param int $code The status code
      * @param string $message A developer-facing error message
      */
-    public function __construct($code, $message)
+    public function __construct(int $code, string $message)
     {
         $this->code = $code;
         $this->message = $message;
@@ -51,7 +51,7 @@ class Status
      *
      * @return int
      */
-    public function code()
+    public function code(): int
     {
         return $this->code;
     }
@@ -61,7 +61,7 @@ class Status
      *
      * @return string
      */
-    public function message()
+    public function message(): string
     {
         return $this->message;
     }

--- a/src/Trace/TimeEvent.php
+++ b/src/Trace/TimeEvent.php
@@ -36,7 +36,7 @@ abstract class TimeEvent
      *
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
         $options += [
             'time' => null
@@ -49,7 +49,7 @@ abstract class TimeEvent
      *
      * @return \DateTimeInterface
      */
-    public function time()
+    public function time(): \DateTimeInterface
     {
         return $this->time;
     }
@@ -59,7 +59,7 @@ abstract class TimeEvent
      *
      * @param \DateTimeInterface|int|float $time The time of this event.
      */
-    public function setTime($time = null)
+    public function setTime($time = null): void
     {
         $this->time = $this->formatDate($time);
     }

--- a/src/Trace/Tracer.php
+++ b/src/Trace/Tracer.php
@@ -117,7 +117,7 @@ class Tracer
      *      @type array $headers Optional array of headers to use in place of $_SERVER
      * @return RequestHandler
      */
-    public static function start(ExporterInterface $reporter, array $options = [])
+    public static function start(ExporterInterface $reporter, array $options = []): RequestHandler
     {
         $sampler = array_key_exists('sampler', $options)
             ? $options['sampler']
@@ -187,7 +187,7 @@ class Tracer
      *      <a href="Span.html#method___construct">OpenCensus\Trace\Span::__construct()</a>
      * @return Span
      */
-    public static function startSpan(array $spanOptions = [])
+    public static function startSpan(array $spanOptions = []): Span
     {
         if (!isset(self::$instance)) {
             return new Span();
@@ -213,7 +213,7 @@ class Tracer
      * @param Span $span
      * @return Scope
      */
-    public static function withSpan(Span $span)
+    public static function withSpan(Span $span): Scope
     {
         if (!isset(self::$instance)) {
             return new Scope(function () {
@@ -231,12 +231,12 @@ class Tracer
      *
      *      @type Span $span The span to add the attribute to.
      */
-    public static function addAttribute($attribute, $value, $options = [])
+    public static function addAttribute(string $attribute, string $value, array $options = []): void
     {
         if (!isset(self::$instance)) {
             return;
         }
-        return self::$instance->addAttribute($attribute, $value, $options);
+        self::$instance->addAttribute($attribute, $value, $options);
     }
 
     /**
@@ -249,12 +249,12 @@ class Tracer
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public static function addAnnotation($description, $options = [])
+    public static function addAnnotation(string $description, array $options = []): void
     {
         if (!isset(self::$instance)) {
             return;
         }
-        return self::$instance->addAnnotation($description, $options);
+        self::$instance->addAnnotation($description, $options);
     }
 
     /**
@@ -270,12 +270,12 @@ class Tracer
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public static function addLink($traceId, $spanId, $options = [])
+    public static function addLink(string $traceId, string $spanId, array $options = []): void
     {
         if (!isset(self::$instance)) {
             return;
         }
-        return self::$instance->addLink($traceId, $spanId, $options);
+        self::$instance->addLink($traceId, $spanId, $options);
     }
 
     /**
@@ -293,12 +293,12 @@ class Tracer
      *            uncompressed.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public static function addMessageEvent($type, $id, $options = [])
+    public static function addMessageEvent(string $type, string $id, array $options = []): void
     {
         if (!isset(self::$instance)) {
             return;
         }
-        return self::$instance->addMessageEvent($type, $id, $options);
+        self::$instance->addMessageEvent($type, $id, $options);
     }
 
     /**
@@ -306,7 +306,7 @@ class Tracer
      *
      * @return SpanContext
      */
-    public static function spanContext()
+    public static function spanContext(): SpanContext
     {
         if (!isset(self::$instance)) {
             return new SpanContext(null, null, false);

--- a/src/Trace/Tracer/ContextTracer.php
+++ b/src/Trace/Tracer/ContextTracer.php
@@ -24,6 +24,7 @@ use OpenCensus\Trace\Link;
 use OpenCensus\Trace\MessageEvent;
 use OpenCensus\Trace\Span;
 use OpenCensus\Trace\SpanContext;
+use OpenCensus\Trace\SpanData;
 
 /**
  * This implementation of the TracerInterface manages your trace context throughout
@@ -85,7 +86,7 @@ class ContextTracer implements TracerInterface
      *        <a href="../Span.html#method___construct">OpenCensus\Trace\Span::__construct()</a>
      * @return Span
      */
-    public function startSpan(array $spanOptions = [])
+    public function startSpan(array $spanOptions = []): Span
     {
         $spanOptions += [
             'traceId' => $this->spanContext()->traceId(),
@@ -103,7 +104,7 @@ class ContextTracer implements TracerInterface
      * @param Span $span
      * @return Scope
      */
-    public function withSpan(Span $span)
+    public function withSpan(Span $span): Scope
     {
         array_push($this->spans, $span);
         $prevContext = Context::current()
@@ -128,7 +129,7 @@ class ContextTracer implements TracerInterface
      *
      * @return SpanData[]
      */
-    public function spans()
+    public function spans(): array
     {
         return array_map(function ($span) {
             return $span->spanData();
@@ -144,7 +145,7 @@ class ContextTracer implements TracerInterface
      *
      *      @type Span $span The span to add the attribute to.
      */
-    public function addAttribute($attribute, $value, $options = [])
+    public function addAttribute(string $attribute, string $value, array $options = []): void
     {
         $span = $this->getSpan($options);
         $span->addAttribute($attribute, $value);
@@ -160,7 +161,7 @@ class ContextTracer implements TracerInterface
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addAnnotation($description, $options = [])
+    public function addAnnotation(string $description, array $options = []): void
     {
         $span = $this->getSpan($options);
         $span->addTimeEvent(new Annotation($description, $options));
@@ -179,7 +180,7 @@ class ContextTracer implements TracerInterface
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addLink($traceId, $spanId, $options = [])
+    public function addLink(string $traceId, string $spanId, array $options = []): void
     {
         $span = $this->getSpan($options);
         $span->addLink(new Link($traceId, $spanId, $options));
@@ -200,7 +201,7 @@ class ContextTracer implements TracerInterface
      *            uncompressed.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addMessageEvent($type, $id, $options = [])
+    public function addMessageEvent(string $type, string $id, array $options = []): void
     {
         $span = $this->getSpan($options);
         $span->addTimeEvent(new MessageEvent($type, $id, $options));
@@ -211,14 +212,14 @@ class ContextTracer implements TracerInterface
      *
      * @return SpanContext
      */
-    public function spanContext()
+    public function spanContext(): SpanContext
     {
         $context = Context::current();
         return new SpanContext(
             $context->value('traceId'),
             $context->value('spanId'),
             $context->value('enabled'),
-            $context->value('fromHeader')
+            $context->value('fromHeader', false)
         );
     }
 
@@ -227,12 +228,12 @@ class ContextTracer implements TracerInterface
      *
      * @return bool
      */
-    public function enabled()
+    public function enabled(): bool
     {
         return $this->spanContext()->enabled();
     }
 
-    private function getSpan($options = [])
+    private function getSpan(array $options = []): Span
     {
         return array_key_exists('span', $options)
             ? $options['span']

--- a/src/Trace/Tracer/ExtensionTracer.php
+++ b/src/Trace/Tracer/ExtensionTracer.php
@@ -82,8 +82,9 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      *
      * @param array $spanOptions [optional] Options for the span. See
      *      <a href="../Span.html#method___construct">OpenCensus\Trace\Span::__construct()</a>
+     * @return Span
      */
-    public function startSpan(array $spanOptions)
+    public function startSpan(array $spanOptions): Span
     {
         if (!array_key_exists('name', $spanOptions)) {
             $spanOptions['name'] = $this->generateSpanName();
@@ -99,7 +100,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      * @param Span $span
      * @return Scope
      */
-    public function withSpan(Span $span)
+    public function withSpan(Span $span): Scope
     {
         $spanData = $span->spanData();
         $startTime = $spanData->startTime()
@@ -134,7 +135,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      *
      * @return Span[]
      */
-    public function spans()
+    public function spans(): array
     {
         // each span returned from opencensus_trace_list should be a
         // OpenCensus\Span object
@@ -153,7 +154,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      *
      *      @type Span $span The span to add the attribute to.
      */
-    public function addAttribute($attribute, $value, $options = [])
+    public function addAttribute(string $attribute, string $value, array $options = []): void
     {
         if (array_key_exists('span', $options)) {
             $options['spanId'] = $options['span']->spanId();
@@ -171,7 +172,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addAnnotation($description, $options = [])
+    public function addAnnotation(string $description, array $options = []): void
     {
         if (array_key_exists('span', $options)) {
             $options['spanId'] = $options['span']->spanId();
@@ -192,7 +193,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addLink($traceId, $spanId, $options = [])
+    public function addLink(string $traceId, string $spanId, array $options = []): void
     {
         if (array_key_exists('span', $options)) {
             $options['spanId'] = $options['span']->spanId();
@@ -215,7 +216,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      *            uncompressed.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addMessageEvent($type, $id, $options = [])
+    public function addMessageEvent(string $type, string $id, array $options = []): void
     {
         if (array_key_exists('span', $options)) {
             $options['spanId'] = $options['span']->spanId();
@@ -228,7 +229,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      *
      * @return SpanContext
      */
-    public function spanContext()
+    public function spanContext(): SpanContext
     {
         $context = opencensus_trace_context();
         return new SpanContext(
@@ -243,7 +244,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      *
      * @return bool
      */
-    public function enabled()
+    public function enabled(): bool
     {
         return $this->spanContext()->enabled();
     }
@@ -255,7 +256,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      * @param string $attribute The name of the attribute added
      * @param string $value The attribute value
      */
-    public function attributeAdded(Span $span, $attribute, $value)
+    public function attributeAdded(Span $span, string $attribute, string $value): void
     {
         // If the span is already attached (managed by the extension), then
         // tell the extension to add the attribute.
@@ -272,7 +273,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      * @param Span $span The span the link was added to
      * @param Link $link The link added to the span
      */
-    public function linkAdded(Span $span, Link $link)
+    public function linkAdded(Span $span, Link $link): void
     {
         // If the span is already attached (managed by the extension), then
         // tell the extension to add the link.
@@ -291,7 +292,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      * @param Span $span The span the time event was added to
      * @param TimeEvent $timeEvent The time event added to the span
      */
-    public function timeEventAdded(Span $span, TimeEvent $timeEvent)
+    public function timeEventAdded(Span $span, TimeEvent $timeEvent): void
     {
         if ($span->attached()) {
             if ($timeEvent instanceof Annotation) {
@@ -317,7 +318,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
      *
      * @return string
      */
-    private function generateSpanName()
+    private function generateSpanName(): string
     {
         // Try to find the first stacktrace class entry that doesn't start with OpenCensus\Trace
         foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $bt) {
@@ -333,7 +334,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
         return uniqid('span');
     }
 
-    private function mapSpan($span, $traceId)
+    private function mapSpan($span, string $traceId): SpanData
     {
         return new SpanData(
             $span->name(),
@@ -353,7 +354,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
         );
     }
 
-    private function getKind($span)
+    private function getKind(Span $span): string
     {
         if (method_exists($span, 'kind')) {
             return $span->kind();
@@ -361,7 +362,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
         return Span::KIND_UNSPECIFIED;
     }
 
-    private function getSameProcessAsParentSpan($span)
+    private function getSameProcessAsParentSpan(Span $span): bool
     {
         if (method_exists($span, 'sameProcessAsParentSpan')) {
             return $span->sameProcessAsParentSpan();
@@ -369,7 +370,7 @@ class ExtensionTracer implements TracerInterface, SpanEventHandlerInterface
         return true;
     }
 
-    private function mapLink($link)
+    private function mapLink($link): Link
     {
         return new Link($link->traceId(), $link->spanId(), $link->options());
     }

--- a/src/Trace/Tracer/NullTracer.php
+++ b/src/Trace/Tracer/NullTracer.php
@@ -50,7 +50,7 @@ class NullTracer implements TracerInterface
      *      <a href="../Span.html#method___construct">OpenCensus\Trace\Span::__construct()</a>
      * @return Span
      */
-    public function startSpan(array $spanOptions)
+    public function startSpan(array $spanOptions): Span
     {
         return new Span($spanOptions);
     }
@@ -62,7 +62,7 @@ class NullTracer implements TracerInterface
      * @param Span $span
      * @return Scope
      */
-    public function withSpan(Span $span)
+    public function withSpan(Span $span): Scope
     {
         return new Scope(function () {
         });
@@ -73,7 +73,7 @@ class NullTracer implements TracerInterface
      *
      * @return SpanData[]
      */
-    public function spans()
+    public function spans(): array
     {
         return [];
     }
@@ -87,7 +87,7 @@ class NullTracer implements TracerInterface
      *
      *      @type Span $span The span to add the attribute to.
      */
-    public function addAttribute($attribute, $value, $options = [])
+    public function addAttribute(string $attribute, string $value, array $options = []): void
     {
     }
 
@@ -101,7 +101,7 @@ class NullTracer implements TracerInterface
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addAnnotation($description, $options = [])
+    public function addAnnotation(string $description, array $options = []): void
     {
     }
 
@@ -118,7 +118,7 @@ class NullTracer implements TracerInterface
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addLink($traceId, $spanId, $options = [])
+    public function addLink(string $traceId, string $spanId, array $options = []): void
     {
     }
 
@@ -137,7 +137,7 @@ class NullTracer implements TracerInterface
      *            uncompressed.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addMessageEvent($type, $id, $options = [])
+    public function addMessageEvent(string $type, string $id, array $options = []): void
     {
     }
 
@@ -146,7 +146,7 @@ class NullTracer implements TracerInterface
      *
      * @return SpanContext
      */
-    public function spanContext()
+    public function spanContext(): SpanContext
     {
         return new SpanContext(null, null, false);
     }
@@ -156,7 +156,7 @@ class NullTracer implements TracerInterface
      *
      * @return bool
      */
-    public function enabled()
+    public function enabled(): bool
     {
         return false;
     }

--- a/src/Trace/Tracer/TracerInterface.php
+++ b/src/Trace/Tracer/TracerInterface.php
@@ -17,6 +17,7 @@
 
 namespace OpenCensus\Trace\Tracer;
 
+use OpenCensus\Core\Scope;
 use OpenCensus\Trace\SpanContext;
 use OpenCensus\Trace\Span;
 use OpenCensus\Trace\SpanData;
@@ -44,8 +45,9 @@ interface TracerInterface
      * The newly created span is not attached to the current context.
      *
      * @param  array  $spanOptions [description]
+     * @return Span
      */
-    public function startSpan(array $spanOptions);
+    public function startSpan(array $spanOptions): Span;
 
     /**
      * Attaches the provided span as the current span and returns a Scope
@@ -54,14 +56,14 @@ interface TracerInterface
      * @param Span $span
      * @return Scope
      */
-    public function withSpan(Span $span);
+    public function withSpan(Span $span): Scope;
 
     /**
      * Return the spans collected.
      *
      * @return SpanData[]
      */
-    public function spans();
+    public function spans(): array;
 
     /**
      * Add an attribute to the provided Span
@@ -72,7 +74,7 @@ interface TracerInterface
      *
      *      @type Span $span The span to add the attribute to.
      */
-    public function addAttribute($attribute, $value, $options = []);
+    public function addAttribute(string $attribute, string $value, array $options = []): void;
 
     /**
      * Add an annotation to the provided Span
@@ -84,7 +86,7 @@ interface TracerInterface
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addAnnotation($description, $options = []);
+    public function addAnnotation(string $description, array $options = []): void;
 
     /**
      * Add a link to the provided Span
@@ -99,7 +101,7 @@ interface TracerInterface
      *      @type array $attributes Attributes for this annotation.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addLink($traceId, $spanId, $options = []);
+    public function addLink(string $traceId, string $spanId, array $options = []): void;
 
     /**
      * Add an message event to the provided Span
@@ -116,19 +118,19 @@ interface TracerInterface
      *            uncompressed.
      *      @type \DateTimeInterface|int|float $time The time of this event.
      */
-    public function addMessageEvent($type, $id, $options = []);
+    public function addMessageEvent(string $type, string $id, array $options = []): void;
 
     /**
      * Returns the current SpanContext
      *
      * @return SpanContext
      */
-    public function spanContext();
+    public function spanContext(): SpanContext;
 
     /**
      * Whether or not this tracer is enabled.
      *
      * @return bool
      */
-    public function enabled();
+    public function enabled(): bool;
 }

--- a/src/Utils/PrintableTrait.php
+++ b/src/Utils/PrintableTrait.php
@@ -28,7 +28,7 @@ trait PrintableTrait
      * @param string $str string to test.
      * @return bool returns true if string is printable.
      */
-    private static function isPrintable($str)
+    private static function isPrintable(string $str): bool
     {
         for ($i = 0; $i < strlen($str); $i++) {
             if (!($str[$i] >= ' ' && $str[$i] <= '~')) {

--- a/tests/unit/Trace/RequestHandlerTest.php
+++ b/tests/unit/Trace/RequestHandlerTest.php
@@ -19,6 +19,8 @@ namespace OpenCensus\Tests\Unit\Trace;
 
 require_once __DIR__ . '/mock_http_response_code.php';
 
+use function foo\func;
+use function func_get_args;
 use OpenCensus\Trace\Annotation;
 use OpenCensus\Trace\Link;
 use OpenCensus\Trace\MessageEvent;
@@ -33,6 +35,8 @@ use OpenCensus\Trace\Tracer\NullTracer;
 use OpenCensus\Trace\Propagator\HttpHeaderPropagator;
 use OpenCensus\Trace\MockHttpResponseCode;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use function var_dump;
 
 /**
  * @group trace
@@ -55,6 +59,7 @@ class RequestHandlerTest extends TestCase
     public function testCanTrackContext()
     {
         $this->sampler->shouldSample()->willReturn(true);
+        $this->exporter->export(Argument::any())->willReturn('');
 
         $rt = new RequestHandler(
             $this->exporter->reveal(),
@@ -670,6 +675,7 @@ class RequestHandlerTest extends TestCase
 
     public function testNoStatusOfRootSpanOnExitWithoutHttpResponse()
     {
+        $this->exporter->export(Argument::any())->willReturn('');
         $this->sampler->shouldSample()->willReturn(true);
         $rt = new RequestHandler(
             $this->exporter->reveal(),
@@ -693,6 +699,7 @@ class RequestHandlerTest extends TestCase
 
     public function testSetsStatusOfRootSpanOnExitWithHttpResponse()
     {
+        $this->exporter->export(Argument::any())->willReturn('');
         $this->sampler->shouldSample()->willReturn(true);
         $rt = new RequestHandler(
             $this->exporter->reveal(),


### PR DESCRIPTION
Hi,

This PR adds types and return types where they are missing.

Since the software is in pre-alpha, maybe we could do it now before it's tagged as stable.

I'm not sure what to do with `SpanData::$traceId`, the argument is documented as `string` but a lot of tests are failing because `null` is given instead. So I'm not sure if the tests are wrong or if the documentation is wrong…

```
25) OpenCensus\Tests\Unit\Trace\Tracer\ContextTracerTest::testSetStartTime
TypeError: Argument 2 passed to OpenCensus\Trace\SpanData::__construct() must be of the type string, null given, called in /Volumes/git/olvlvl/opencensus-php/src/Trace/Span.php on line 297
```
