### PR TITLE
Use PHPUnit 7.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "cache/adapter-common": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^7.5",
         "squizlabs/php_codesniffer": "2.*",
         "twig/twig": "~2.0 || ~1.35",
         "symfony/yaml": "~3.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/unit/bootstrap.php" colors="true">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+    bootstrap="./tests/unit/bootstrap.php"
+    colors="true">
   <testsuites>
-    <testsuite>
+    <testsuite name="units">
       <directory>tests/unit</directory>
     </testsuite>
   </testsuites>
@@ -9,9 +13,7 @@
     <whitelist>
       <directory suffix=".php">src</directory>
       <exclude>
-        <directory suffix=".php">src/*/V[!a-zA-Z]*</directory>
-        <directory suffix=".php">src/*/*/V[!a-zA-Z]*</directory>
-        <directory suffix=".php">src/*/*/*/V[!a-zA-Z]*</directory>
+        <file>src/Version.php</file>
       </exclude>
     </whitelist>
   </filter>

--- a/tests/unit/Core/ContextTest.php
+++ b/tests/unit/Core/ContextTest.php
@@ -68,9 +68,6 @@ class ContextTest extends TestCase
         $this->assertEquals($initialContext, Context::current());
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testRestoringCurrentContextRequiresSameObject()
     {
         $context = new Context(['foo' => 'bar']);
@@ -79,6 +76,7 @@ class ContextTest extends TestCase
         $other = new Context(['foo' => 'bar']);
         $this->assertFalse($prevContext === $other);
 
+        $this->expectException(\PHPUnit\Framework\Error\Warning::class);
         $other->detach($other);
     }
 

--- a/tests/unit/Trace/Propagator/BinaryFormatterTest.php
+++ b/tests/unit/Trace/Propagator/BinaryFormatterTest.php
@@ -49,13 +49,12 @@ class BinaryFormatterTest extends TestCase
         $this->assertEquals($hex, bin2hex($formatter->serialize($context)));
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error_Warning
-     */
     public function testDeserializeBadData()
     {
         $formatter = new BinaryFormatter();
-        $context = $formatter->deserialize(hex2bin("0012341abc"));
+
+        $this->expectException(\PHPUnit\Framework\Error\Warning::class);
+        $formatter->deserialize(hex2bin("0012341abc"));
     }
 
     public function testDeserializeBadDataReturnsEmptySpanContext()


### PR DESCRIPTION
Hi,

This PR updates the dependencies to use PHPUnit 7.5 instead of 5.

**Note**: I replaced the directory exclusions with a single file exclusion. The value must comply with `xs:anyURI`. I'm not sure what the exclusion was about, excluding `V123...` files?