### PR TITLE
Adding Docker test run functionality

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,9 @@ To run all tests, the following command may be invoked:
 $ composer tests
 ```
 
+Tests can additionally be run using the provided docker wrapper:
+`scripts/dockertest`
+
 ## Coding Style
 
 Please follow the established coding style in the library. OpenCensus for PHP

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM php:7.2-buster
+RUN apt-get update && apt-get -y install git  # Needed to pull composer dependencies
+COPY . /usr/src/opencensus-tests
+WORKDIR /usr/src/opencensus-tests
+RUN curl -sS https://getcomposer.org/installer | php
+RUN mv composer.phar /usr/local/bin/composer
+RUN chmod +x /usr/local/bin/composer
+RUN composer install
+ENTRYPOINT ["./vendor/phpunit/phpunit/phpunit"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM php:7.2-buster
-RUN apt-get update && apt-get -y install git  # Needed to pull composer dependencies
-COPY . /usr/src/opencensus-tests
-WORKDIR /usr/src/opencensus-tests
-RUN curl -sS https://getcomposer.org/installer | php
-RUN mv composer.phar /usr/local/bin/composer
-RUN chmod +x /usr/local/bin/composer
+RUN apt-get update && apt-get -y install git zip \
+&& curl -sS https://getcomposer.org/installer | php \
+&& mv composer.phar /usr/local/bin/composer \
+&& chmod +x /usr/local/bin/composer
+COPY . /usr/src/myapp
+WORKDIR /usr/src/myapp
 RUN composer install
-ENTRYPOINT ["./vendor/phpunit/phpunit/phpunit"]
+ENTRYPOINT ["./vendor/phpunit/phpunit/phpunit", "--colors=always"]

--- a/scripts/dockertest
+++ b/scripts/dockertest
@@ -1,0 +1,3 @@
+#!/bin/bash                               
+docker build -t opencensus-php-tests .
+docker run -it opencensus-php-tests


### PR DESCRIPTION
I've added a script that performs the test runs for this repository with docker.  Execution comes in the form of a `scripts/dockertest` command.  Output looks as so (with the build output truncated for brevity):

```
~ scripts/dockertest

PHPUnit 5.7.27 by Sebastian Bergmann and contributors.

Error:         No code coverage driver is available

....................................S..........................  63 / 217 ( 29%)
............................................................... 126 / 217 ( 58%)
............................................................... 189 / 217 ( 87%)
SSSSSSSSSSSSSSSSSSSSSS......                                    217 / 217 (100%)

Time: 167 ms, Memory: 10.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 217, Assertions: 491, Skipped: 23.
```