### PR TITLE
Fix failing test for PHP 7.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,16 @@ jobs:
     docker:
       - image: circleci/php:7.3-zts-node
 
+  php74:
+    <<: *unit-config
+    docker:
+      - image: circleci/php:7.4-node
+
+  php74-zts:
+    <<: *unit-config
+    docker:
+      - image: circleci/php:7.4-zts-node
+
   php71-32bit:
     <<: *unit-config
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,8 @@ workflows:
       - php72-zts
       - php73
       - php73-zts
+      - php74
+      - php74-zts
       - php71-32bit
       - php71-debug
       - integration

--- a/ext/tests/name_uncastable_object.phpt
+++ b/ext/tests/name_uncastable_object.phpt
@@ -19,4 +19,8 @@ var_dump($span->name());
 
 ?>
 --EXPECTF--
-%s fatal error: Object of class UncastableObject could not be converted to string in %s/name_uncastable_object.php on line %d
+Fatal error: %s: Object of class UncastableObject could not be converted to string in %s/name_uncastable_object.php:%d
+Stack trace:
+#0 %s/name_uncastable_object.php(%d): opencensus_trace_begin('foo', Array)
+#1 {main}
+  thrown in %s/name_uncastable_object.php on line %d


### PR DESCRIPTION
Fixes #250

It seems like the structure of the output for the `name_uncastable_object.phpt` test has changed between PHP 7.3 & 7.4.

This PR updates the expected output of the test, and ensures it works on PHP 7.4. However, it breaks it for PHP < 7.4. I'm not sure whether this should be opened against a different/dedicated 7.4 branch?

