### PR TITLE
replace curly braces with square braces

### DIFF
--- a/src/Trace/Propagator/CloudTraceFormatter.php
+++ b/src/Trace/Propagator/CloudTraceFormatter.php
@@ -117,7 +117,7 @@ class CloudTraceFormatter implements FormatterInterface
                 }
             }
             $length = $newlen;
-            $result = $newstring{$divide} . $result;
+            $result = $newstring[$divide] . $result;
         } while ($newlen != 0);
 
         return $result;


### PR DESCRIPTION
To avoid notice "Array and string offset access syntax with curly braces is deprecated" in php 7.4