### PR TITLE
PHP 7.4 Compatibility Fix

### DIFF
--- a/src/Trace/Propagator/CloudTraceFormatter.php
+++ b/src/Trace/Propagator/CloudTraceFormatter.php
@@ -101,7 +101,7 @@ class CloudTraceFormatter implements FormatterInterface
         $result = '';
 
         for ($i = 0; $i < $length; $i++) {
-            $number[$i] = strpos($chars, $numstring{$i});
+            $number[$i] = strpos($chars, $numstring[$i]);
         }
 
         do {
@@ -117,7 +117,7 @@ class CloudTraceFormatter implements FormatterInterface
                 }
             }
             $length = $newlen;
-            $result = $newstring{$divide} . $result;
+            $result = $newstring[$divide] . $result;
         } while ($newlen != 0);
 
         return $result;


### PR DESCRIPTION
- fixes `Deprecated: Array and string offset access syntax with curly braces is deprecated in...`