### PR TITLE
Fix use of curly brace string access deprecated in PHP 7.4.

### DIFF
--- a/src/Trace/Propagator/CloudTraceFormatter.php
+++ b/src/Trace/Propagator/CloudTraceFormatter.php
@@ -101,7 +101,7 @@ class CloudTraceFormatter implements FormatterInterface
         $result = '';
 
         for ($i = 0; $i < $length; $i++) {
-            $number[$i] = strpos($chars, $numstring{$i});
+            $number[$i] = strpos($chars, $numstring[$i]);
         }
 
         do {
@@ -117,7 +117,7 @@ class CloudTraceFormatter implements FormatterInterface
                 }
             }
             $length = $newlen;
-            $result = $newstring{$divide} . $result;
+            $result = $newstring[$divide] . $result;
         } while ($newlen != 0);
 
         return $result;


### PR DESCRIPTION
See https://wiki.php.net/rfc/deprecate_curly_braces_array_access.

Without this, the Cloud Trace exporter triggers a `Array and string offset access syntax with curly braces is deprecated` warning when using PHP 7.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/census-instrumentation/opencensus-php/260)
<!-- Reviewable:end -->
