### PR TITLE
Support ramsey/uuid v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=7.1",
-        "ramsey/uuid": "~3",
+        "ramsey/uuid": "^3.0 || ^4.0",
         "psr/log": "^1.0",
         "psr/cache": "^1.0",
         "cache/adapter-common": "^1.0"


### PR DESCRIPTION
Support ramsey uuid v4 to avoid the conflict with opencensus/opencensus-exporter-stackdriver