### PR TITLE
Allow psr/log 2.0 and 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=7.1",
         "ramsey/uuid": "^3.0 || ^4.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "cache/adapter-common": "^1.0"
     },


### PR DESCRIPTION
Hello,

I think it was missing during this PR https://github.com/census-instrumentation/opencensus-php/pull/270

psr/log 2.0 and 3.0 add support for php 8.