### PR TITLE
fix 8.2 deprecation

### DIFF
--- a/ext/tests/basic_context.phpt
+++ b/ext/tests/basic_context.phpt
@@ -4,7 +4,7 @@ OpenCensus Trace: Basic Context Test
 <?php
 
 $res = opencensus_trace_set_context('traceid', 1234);
-echo "Set context: ${res}\n";
+echo "Set context: {$res}\n";
 
 $context = opencensus_trace_context();
 $class = get_class($context);

--- a/ext/tests/inherit_context.phpt
+++ b/ext/tests/inherit_context.phpt
@@ -4,7 +4,7 @@ OpenCensus Trace: Root inherits from context
 <?php
 
 $res = opencensus_trace_set_context('traceid', 1234);
-echo "Set context: ${res}\n";
+echo "Set context: {$res}\n";
 
 opencensus_trace_begin('root', []);
 opencensus_trace_begin('inner', []);


### PR DESCRIPTION
Notice `tests/span_stacktrace_default.phpt` is also failing since 8.1
