### PR TITLE
update psr/log with v2 or v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=7.1",
         "ramsey/uuid": "^3.0 || ^4.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "cache/adapter-common": "^1.0"
     },


### PR DESCRIPTION
Only the logger interface is injected, therefore no compatibility problems should exist: https://github.com/census-instrumentation/opencensus-php/blob/007b35d8f7ed21cab9aa47406578ae02f73f91c5/src/Trace/Exporter/LoggerExporter.php#L74