### PR TITLE
A couple of PHP 8.2 fixes

### DIFF
--- a/src/Trace/Propagator/BinaryFormatter.php
+++ b/src/Trace/Propagator/BinaryFormatter.php
@@ -59,7 +59,7 @@ class BinaryFormatter implements FormatterInterface
      */
     public function serialize(SpanContext $context)
     {
-        $spanHex = str_pad($context->spanId(), 16, "0", STR_PAD_LEFT);
+        $spanHex = str_pad($context->spanId() ?? "", 16, "0", STR_PAD_LEFT);
         $traceOptions = $context->enabled() ? self::OPTION_ENABLED : 0;
         return pack("CCH*CH*CC", 0, 0, $context->traceId(), 1, $spanHex, 2, $traceOptions);
     }

--- a/src/Trace/SpanContext.php
+++ b/src/Trace/SpanContext.php
@@ -52,6 +52,8 @@ class SpanContext
      */
     private $enabled;
 
+	private ?bool $fromHeader;
+
     /**
      * Creates a new SpanContext instance
      *


### PR DESCRIPTION
Avoid passing `null` to `str_pad()` and declare the missing `fromHeader` property in `SpanContext.php`