### PR TITLE
Php 8.2 deprecation fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,16 @@ jobs:
     docker:
       - image: circleci/php:8.0-zts-node
 
+  php82:
+    <<: *unit-config
+    docker:
+      - image: circleci/php:8.2-node
+
+  php82-zts:
+    <<: *unit-config
+    docker:
+      - image: circleci/php:8.2-zts-node
+
   # Integration tests running on PHP 7.4. When updating these, please also update `integration-8.0` further down.
   integration-7.4:
     docker:
@@ -312,6 +322,101 @@ jobs:
       DB_USERNAME: mysql
       DB_PASSWORD: mysql
       DB_DATABASE: mysqldb
+
+# Integration tests running on PHP 8.2. When updating these, please also update `integration-7.4` further down.
+  integration-8.2:
+    docker:
+      - image: circleci/php:8.2-node
+      - image: memcached
+      - image: mysql:5.7
+        environment:
+          MYSQL_USER: mysql
+          MYSQL_PASSWORD: mysql
+          MYSQL_DATABASE: mysqldb
+          MYSQL_RANDOM_ROOT_PASSWORD: yes
+      - image: postgres:9.6
+        environment:
+          POSTGRES_PASSWORD: pgsql
+          POSTGRES_USER: postgres
+    steps:
+      - checkout
+      - run:
+          name: Install build tools
+          command: |
+            sudo apt-get update -y
+            sudo apt-get install -y -q --no-install-recommends \
+              build-essential \
+              g++ \
+              gcc \
+              libc-dev \
+              libpqxx-dev \
+              make \
+              autoconf \
+              git \
+              unzip
+      - run:
+          name: Install opencensus extension
+          command: |
+            cd ext
+            phpize
+            ./configure --enable-opencensus
+            sudo make install
+            sudo docker-php-ext-enable opencensus
+      - run:
+          name: Install memcached extension
+          command: |
+            sudo apt-get install -y -q --no-install-recommends \
+              libmemcached11 libmemcached-dev zlib1g-dev zlib1g
+            sudo pecl install memcached <<<''
+            sudo docker-php-ext-enable memcached
+      - run:
+          name: Install pdo_mysql extension
+          command: sudo docker-php-ext-install pdo_mysql
+      - run:
+          name: Install mysqli extension
+          command: sudo docker-php-ext-install mysqli
+      - run:
+          name: Install pgsql extension
+          command: sudo docker-php-ext-install pgsql
+      - run:
+          name: Install pcntl extension
+          command: sudo docker-php-ext-install pcntl
+      - run:
+          name: Curl test
+          command: tests/integration/curl/test.sh
+      - run:
+          name: Guzzle 5 test
+          command: tests/integration/guzzle5/test.sh
+      - run:
+          name: Guzzle 6 test
+          command: tests/integration/guzzle6/test.sh
+      - run:
+          name: Laravel test
+          command: tests/integration/laravel/test.sh
+      - run:
+          name: Memcached test
+          command: tests/integration/memcached/test.sh
+      - run:
+          name: Pgsql test
+          command: tests/integration/pgsql/test.sh
+# Skipped due to a dependency incompatibility between "cache/adapter-common" and "psr/cache".
+# TODO(mrmage): Re-enable this step once "cache/adapter-common" supports "psr/cache" v2.0/v3.0.
+#      - run:
+#          name: Symfony 4 test
+#          command: tests/integration/symfony4/test.sh
+#          environment:
+#            DATABASE_URL: mysql://mysql:mysql@127.0.0.1:3306/mysqldb
+# Skipped because "wp-cli" is currently not compatible with PHP 8 (see https://github.com/wp-cli/wp-cli/issues/5452).
+# TODO(mrmage): Re-enable this step once "wp-cli" supports PHP 8.
+#      - run:
+#          name: Wordpress test
+#          command: tests/integration/wordpress/test.sh
+    environment:
+      DB_HOST: 127.0.0.1
+      DB_USERNAME: mysql
+      DB_PASSWORD: mysql
+      DB_DATABASE: mysqldb
+
 
 workflows:
   version: 2

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "twig/twig": "~2.0 || ~1.35",
         "symfony/yaml": "~3.3",
         "guzzlehttp/guzzle": "~5.3",
-        "guzzlehttp/psr7": "~1.4"
+        "guzzlehttp/psr7": "~1.4",
+        "phpspec/prophecy": "^1.17"
     },
     "conflict": {
         "ext-opencensus": "< 0.1.0"

--- a/ext/tests/basic_context.phpt
+++ b/ext/tests/basic_context.phpt
@@ -4,7 +4,7 @@ OpenCensus Trace: Basic Context Test
 <?php
 
 $res = opencensus_trace_set_context('traceid', 1234);
-echo "Set context: ${res}\n";
+echo "Set context: {$res}\n";
 
 $context = opencensus_trace_context();
 $class = get_class($context);

--- a/ext/tests/inherit_context.phpt
+++ b/ext/tests/inherit_context.phpt
@@ -4,7 +4,7 @@ OpenCensus Trace: Root inherits from context
 <?php
 
 $res = opencensus_trace_set_context('traceid', 1234);
-echo "Set context: ${res}\n";
+echo "Set context: {$res}\n";
 
 opencensus_trace_begin('root', []);
 opencensus_trace_begin('inner', []);

--- a/src/Trace/Propagator/BinaryFormatter.php
+++ b/src/Trace/Propagator/BinaryFormatter.php
@@ -59,7 +59,7 @@ class BinaryFormatter implements FormatterInterface
      */
     public function serialize(SpanContext $context)
     {
-        $spanHex = str_pad($context->spanId(), 16, "0", STR_PAD_LEFT);
+        $spanHex = str_pad($context->spanId() ?? "", 16, "0", STR_PAD_LEFT);
         $traceOptions = $context->enabled() ? self::OPTION_ENABLED : 0;
         return pack("CCH*CH*CC", 0, 0, $context->traceId(), 1, $spanHex, 2, $traceOptions);
     }

--- a/src/Trace/SpanContext.php
+++ b/src/Trace/SpanContext.php
@@ -53,6 +53,11 @@ class SpanContext
     private $enabled;
 
     /**
+     * @var bool Whether or not the context was detected from an incoming header.
+     */
+    private $fromHeader;
+
+    /**
      * Creates a new SpanContext instance
      *
      * @param string $traceId The current traceId. If not set, one will be


### PR DESCRIPTION
These changes fix deprecation errors on php 8.2

phpspec/prophecy is required by tests but was missing in composer.json